### PR TITLE
docs(*): documentation for this repository - I37

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Other channels for support are:
 
 If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github-issues]. Even better, you can submit a Pull Request with a fix.
 
-**Please see the **[**Submission Guidelines**](#submit)** below.**
+**Please see the **[**Submission Guidelines**](contributing.md#submit)** below.**
 
 ### <a name="feature"></a> Missing a Feature?
 
@@ -55,7 +55,7 @@ If you would like to implement a new feature then consider what kind of change i
 
   as a Pull Request. See the section about [Pull Request Submission Guidelines](contributing.md#submit-pr), and
 
-  for detailed information the [core development documentation](developers/).
+  for detailed information the [core development documentation][developers].
 
 ### <a name="docs"></a> Want a Doc Fix?
 
@@ -65,7 +65,7 @@ If you want to help improve the docs, it's a good idea to let others know what y
 
 If you're making a small change \(typo, phrasing\) don't worry about filing an issue first. Use the friendly blue "Improve this doc" button at the top right of the doc page to fork the repository in-place and make a quick change on the fly. The commit message is preformatted to the right type and scope, so you only have to add the description.
 
-For large fixes, please build and test the documentation before submitting the PR to be sure you haven't accidentally introduced any layout or formatting issues. You should also make sure that your commit message follows the [**Commit Message Guidelines**](developers/#commits).
+For large fixes, please build and test the documentation before submitting the PR to be sure you haven't accidentally introduced any layout or formatting issues. You should also make sure that your commit message follows the [**Commit Message Guidelines**][developers.commits].
 
 ## <a name="submit"></a> Issue Submission Guidelines
 
@@ -165,6 +165,9 @@ After your pull request is merged, you can safely delete your branch and pull th
     git pull --ff upstream master
   ```
 
+## License <a name="license"></a>
+Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.
+
 [coc]: https://github.com/accordproject/docs/blob/master/Accord%20Project%20Code%20of%20Conduct.pdf
 [dco]: https://developercertificate.org/
 [developers]: DEVELOPERS.md
@@ -177,6 +180,3 @@ After your pull request is merged, you can safely delete your branch and pull th
 [github-new-issue]: https://github.com/accordproject/cicero-ui/issues/new
 [github]: https://github.com/accordproject/cicero-ui
 [pulls]: https://github.com/accordproject/cicero-ui/pulls
-
-## License <a name="license"></a>
-Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,182 @@
+# Contributing to Cicero-UI
+
+> Thanks to the angularJS team for the bulk of this text!
+
+We'd love for you to contribute to our source code and to make Cicero-UI even better than it is today! Here are the guidelines we'd like you to follow:
+
+* [Code of Conduct](contributing.md#coc)
+* [Questions and Problems](contributing.md#question)
+* [Issues and Bugs](contributing.md#issue)
+* [Feature Requests](contributing.md#feature)
+* [Improving Documentation](contributing.md#docs)
+* [Issue Submission Guidelines](contributing.md#submit)
+* [Pull Request Submission Guidelines](contributing.md#submit-pr)
+* [Signing the CLA](contributing.md#cla)
+
+## <a name="coc"></a> Code of Conduct
+
+Help us keep Cicero-UI open and inclusive. Please read and follow our [Code of Conduct][coc].
+
+## <a name="requests"></a> Questions, Bugs, Features
+
+### <a name="question"></a> Got a Question or Problem?
+
+Do not open issues for general support questions as we want to keep GitHub issues for bug reports and feature requests. You've got much better chances of getting your question answered on dedicated support platforms, the best being \[Stack Overflow\](http://stackoverflow.com/questions/tagged/cicero).
+
+Stack Overflow is a much better place to ask questions since:
+
+* There are thousands of people willing to help on Stack Overflow
+* Questions and answers stay available for public viewing so your question / answer might help someone else
+* Stack Overflow's voting system assures that the best answers are prominently visible.
+
+To save your and our time, we will systematically close all issues that are requests for general support and redirect people to the section you are reading right now.
+
+Other channels for support are:
+
+* Cicero Slack Channel on the [Accord Project slack](https://accord-project.slack.com/messages/CA08NAHQS)
+
+### <a name="issue"></a> Found an Issue or Bug?
+
+If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github-issues]. Even better, you can submit a Pull Request with a fix.
+
+**Please see the **[**Submission Guidelines**](#submit)** below.**
+
+### <a name="feature"></a> Missing a Feature?
+
+You can request a new feature by submitting an issue to our [GitHub Repository][github-issues].
+
+If you would like to implement a new feature then consider what kind of change it is:
+
+* **Major Changes** that you wish to contribute to the project should be discussed first in an
+
+  [GitHub issue][github-issues] that clearly outlines the changes and benefits of the feature.
+
+* **Small Changes** can directly be crafted and submitted to the [GitHub Repository][github]
+
+  as a Pull Request. See the section about [Pull Request Submission Guidelines](contributing.md#submit-pr), and
+
+  for detailed information the [core development documentation](developers/).
+
+### <a name="docs"></a> Want a Doc Fix?
+
+Should you have a suggestion for the documentation, you can open an issue and outline the problem or improvement you have - however, creating the doc fix yourself is much better!
+
+If you want to help improve the docs, it's a good idea to let others know what you're working on to minimize duplication of effort. Create a new issue \(or comment on a related existing one\) to let others know what you're working on.
+
+If you're making a small change \(typo, phrasing\) don't worry about filing an issue first. Use the friendly blue "Improve this doc" button at the top right of the doc page to fork the repository in-place and make a quick change on the fly. The commit message is preformatted to the right type and scope, so you only have to add the description.
+
+For large fixes, please build and test the documentation before submitting the PR to be sure you haven't accidentally introduced any layout or formatting issues. You should also make sure that your commit message follows the [**Commit Message Guidelines**](developers/#commits).
+
+## <a name="submit"></a> Issue Submission Guidelines
+
+Before you submit your issue search the archive, maybe your question was already answered.
+
+If your issue appears to be a bug, and hasn't been reported, open a new issue. Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
+
+The "[new issue][github-new-issue]" form contains a number of prompts that you should fill out to make it easier to understand and categorize the issue.
+
+**If you get help, help others. Good karma rulez!**
+
+## <a name="submit-pr"></a> Pull Request Submission Guidelines
+
+Before you submit your pull request consider the following guidelines:
+
+* Search [GitHub][pulls] for an open or closed Pull Request
+
+  that relates to your submission. You don't want to duplicate effort.
+
+* Create the [development environment][developers.setup]
+* Make your changes in a new git branch:
+
+  ```text
+    git checkout -b my-fix-branch master
+  ```
+
+* Create your patch commit, **including appropriate test cases**.
+* Follow our [Coding Rules][developers.rules].
+* Ensure you provide a DCO sign-off for your commits using the -s option of git commit. For more information see https://github.com/probot/dco#how-it-works
+* If the changes affect public APIs, change or add relevant [documentation][developers.documentation].
+* Run the [unit][developers.unit-tests] test suite, and ensure that all tests pass.
+
+* Commit your changes using a descriptive commit message that follows our [commit message conventions][developers.commits]. Adherence to the [commit message conventions][developers.commits] is required, because release notes are automatically generated from these messages.
+
+  ```text
+    git commit -a
+  ```
+
+  Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
+
+* Before creating the Pull Request, package and run all tests a last time:
+
+  ```text
+    npm run test
+  ```
+
+* Push your branch to GitHub:
+
+  ```text
+    git push origin my-fix-branch
+  ```
+
+* In GitHub, send a pull request to `cicero-ui:master`. This will trigger the check of the [Contributor License Agreement](contributing.md#cla) and the Travis integration.
+* If you find that the Travis integration has failed, look into the logs on Travis to find out if your changes caused test failures, the commit message was malformed etc. If you find that the tests failed or times out for unrelated reasons, you can ping a team member so that the build can be restarted.
+* If we suggest changes, then:
+  * Make the required updates.
+  * Re-run the test suite to ensure tests are still passing.
+  * Commit your changes to your branch \(e.g. `my-fix-branch`\).
+  * Push the changes to your GitHub repository \(this will update your Pull Request\).
+
+    You can also amend the initial commits and force push them to the branch.
+
+    ```text
+    git rebase master -i
+    git push origin my-fix-branch -f
+    ```
+
+    This is generally easier to follow, but seperate commits are useful if the Pull Request contains iterations that might be interesting to see side-by-side.
+
+That's it! Thank you for your contribution!
+
+#### After your pull request is merged
+
+After your pull request is merged, you can safely delete your branch and pull the changes from the main \(upstream\) repository:
+
+* Delete the remote branch on GitHub either through the GitHub web UI or your local shell as follows:
+
+  ```text
+    git push origin --delete my-fix-branch
+  ```
+
+* Check out the master branch:
+
+  ```text
+    git checkout master -f
+  ```
+
+* Delete the local branch:
+
+  ```text
+    git branch -D my-fix-branch
+  ```
+
+* Update your master with the latest upstream version:
+
+  ```text
+    git pull --ff upstream master
+  ```
+
+[coc]: https://github.com/accordproject/docs/blob/master/Accord%20Project%20Code%20of%20Conduct.pdf
+[dco]: https://developercertificate.org/
+[developers]: DEVELOPERS.md
+[developers.commits]: DEVELOPERS.md#commits
+[developers.documentation]: DEVELOPERS.md#documentation
+[developers.rules]: DEVELOPERS.md#rules
+[developers.setup]: DEVELOPERS.md#setup
+[developers.unit-tests]: DEVELOPERS.md#unit-tests
+[github-issues]: https://github.com/accordproject/cicero-ui/issues
+[github-new-issue]: https://github.com/accordproject/cicero-ui/issues/new
+[github]: https://github.com/accordproject/cicero-ui
+[pulls]: https://github.com/accordproject/cicero-ui/pulls
+
+## License <a name="license"></a>
+Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,172 @@
+# Developing Cicero-UI
+
+* [Development Setup](#setup)
+* [Coding Rules](#rules)
+* [Commit Message Guidelines](#commits)
+* [Writing Documentation](#documentation)
+
+## <a name="setup"> Development Setup
+
+This document describes how to set up your development environment to build and test Cicero-UI, and
+explains the basic mechanics of using `git`, `node`, `npm`.
+
+### Installing Dependencies
+
+Before you can build Cicero-UI, you must install and configure the following dependencies on your
+machine:
+
+* [Git][git]: The [Github Guide to
+  Installing Git][git-setup] is a good source of information.
+
+* [Node.js v10.15.3 'Dubnium' (LTS)][node]: We use Node to generate the documentation, run a
+  development web server, run tests, and generate distributable files. Depending on your system,
+  you can install Node either from source or as a pre-packaged bundle.
+
+  We recommend using [nvm][nvm] (or
+  [nvm-windows][nvm-windows])
+  to manage and install Node.js, which makes it easy to change the version of Node.js per project.
+
+### Forking Cicero-UI on Github
+
+To contribute code to Cicero-UI, you must have a GitHub account so you can push code to your own
+fork of Cicero-UI and open Pull Requests in the [GitHub Repository][github].
+
+To create a Github account, follow the instructions [here][github-signup].
+Afterwards, go ahead and [fork][github-forking] the
+[main Cicero-UI repository][github].
+
+### Building Cicero-UI
+
+To build Cicero-UI, you clone the source code repository and use lerna to build:
+
+```shell
+# Clone your Github repository:
+git clone https://github.com/<github username>/cicero-ui.git
+
+# Go to the Cicero-UI directory:
+cd cicero-ui
+
+# Add the main Cicero-UI repository as an upstream remote to your repository:
+git remote add upstream "https://github.com/acccordproject/cicero-ui.git"
+
+# Install node.js dependencies:
+npm install
+```
+
+### <a name="unit-tests"></a> Running the Unit Test Suite
+
+We write unit and integration tests with Enzyme and execute them with Jest. To run all of the
+tests once on Chrome run:
+
+```shell
+npm run test
+```
+
+## <a name="rules"></a> Coding Rules
+
+To ensure consistency throughout the source code, keep these rules in mind as you are working:
+
+* All features or bug fixes **must be tested** by one or more [specs](#unit-tests).
+* All public API methods **must be documented** with jsdoc. To see how we document our APIs, please check
+  out the existing source code and see the section about [writing documentation](#documentation)
+* With the exceptions listed below, we follow the rules contained in
+  [Google's JavaScript Style Guide][google].
+
+## <a name="commits"></a> Git Commit Guidelines
+
+We have very precise rules over how our git commit messages can be formatted.  This leads to **more
+readable messages** that are easy to follow when looking through the **project history**.  But also,
+we use the git commit messages to **generate the Cicero-UI change log**.
+
+The commit message formatting can be added using a typical git workflow or through the use of a CLI
+wizard ([Commitizen][commit]). To use the wizard, run `yarn run commit`
+in your terminal after staging your changes in git.
+
+### Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+### Revert
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header
+of the reverted commit.
+In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit
+being reverted.
+A commit with this format is automatically created by the [`git revert`][git-revert] command.
+
+### Type
+Must be one of the following:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing or correcting existing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
+
+### Scope
+The scope could be anything specifying place of the commit change. For example `engine`,
+`template`, `clause`, etc...
+
+You can use `*` when the change affects more than a single scope.
+
+### Subject
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+[reference GitHub issues that this commit closes][closing-issues].
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines.
+The rest of the commit message is then used for this.
+
+A detailed explanation can be found in this [document][commit-message-format].
+
+## <a name="documentation"></a> Writing Documentation
+
+The Cicero-UI project uses [jsdoc][jsdoc] for all of its code
+documentation.
+
+This means that all the docs are stored inline in the source code and so are kept in sync as it
+changes.
+
+This means that since we generate the documentation from the source code, we can easily provide
+version-specific documentation by simply checking out a version of Cicero-UI and running the build.
+
+[git]: http://git-scm.com/
+[git-setup]: https://help.github.com/en/articles/set-up-git
+[node]: https://nodejs.org/en/
+[nvm]: https://github.com/creationix/nvm
+[nvm-windows]: https://github.com/coreybutler/nvm-windows
+[github-signup]: https://github.com/signup/free
+[github-forking]: http://help.github.com/forking
+[google]: https://google.github.io/styleguide/jsguide.html
+[commit]: https://github.com/commitizen/cz-cli
+[jsdoc]: http://usejsdoc.org/
+
+## License <a name="license"></a>
+Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cicero UI Library
 
+[![Build Status](https://travis-ci.org/accordproject/cicero-ui.svg?branch=master)](https://travis-ci.org/accordproject/cicero-ui) [![npm version](https://badge.fury.io/js/%40accordproject%2Fcicero-ui.svg)](https://badge.fury.io/js/%40accordproject%2Fcicero-ui)
+
 The Accord Project Cicero UI Library can be used for implementing React components in your contract editing studio.
 
 ## Development Instructions - Build
@@ -32,6 +34,7 @@ You will also see any lint errors in the console.
 ### `npm run test`
 
 Launches JEST over the repository.
+Current snapshot tests requires `npm test -- -u` in order to update when all changes are final.
 
 ### `npm run lint`
 
@@ -47,22 +50,15 @@ Your app is ready to be deployed!
 
 ---
 
-## How this project is structured
 
-Packages: 
-- `TemplateLibrary`: Provides a ReactJS component to fetch and display a library of contract and clause templates in the [Accord Project Cicero format](https://github.com/accordproject/cicero).
+## Structure of the Code Repository
 
-[![Travis][build-badge]][build]
-[![npm package][npm-badge]][npm]
-[![Coveralls][coveralls-badge]][coveralls]
+Top level repository (cicero-ui), with sub packages. The entire package is published as an independent npm module:
+- `TemplateLibrary` : Provides a ReactJS component to fetch and display a library of contract and clause templates in the [Accord Project Cicero format][cicero].
+- `ContractEditor` : This is a ReactJS component for a rich text contract editor. It is based on the [@accordproject/markdown-editor][markdown] component.
 
-Describe cicero-ui here.
+[cicero]: https://github.com/accordproject/cicero
+[markdown]: https://github.com/accordproject/markdown-editor
 
-[build-badge]: https://img.shields.io/travis/user/repo/master.png?style=flat-square
-[build]: https://travis-ci.org/user/repo
-
-[npm-badge]: https://img.shields.io/npm/v/npm-package.png?style=flat-square
-[npm]: https://www.npmjs.org/package/npm-package
-
-[coveralls-badge]: https://img.shields.io/coveralls/user/repo/master.png?style=flat-square
-[coveralls]: https://coveralls.io/github/user/repo
+## License <a name="license"></a>
+Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.

--- a/markdown-license.txt
+++ b/markdown-license.txt
@@ -1,0 +1,2 @@
+## License <a name="license"></a>
+Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.

--- a/src/ContractEditor/README.md
+++ b/src/ContractEditor/README.md
@@ -1,0 +1,21 @@
+## Cicero-UI - ContractEditor
+
+### Usage
+
+```
+npm install @accordproject/cicero-ui
+```
+
+```
+import { ContractEditor } from '@accordproject/cicero-ui';
+
+function storeLocal(editor) {
+  localStorage.setItem('markdown-editor', editor.getMarkdown());
+}
+
+ReactDOM.render(<ContractEditor onChange={storeLocal} />, document.getElementById('root'));
+```
+
+### Props
+
+Available props incoming:

--- a/src/TemplateLibrary/README.md
+++ b/src/TemplateLibrary/README.md
@@ -1,0 +1,38 @@
+## Cicero-UI - TemplateLibrary
+
+### Usage
+
+```
+npm install @accordproject/cicero-ui
+```
+
+```
+import { TemplateLibrary } from '@accordproject/cicero-ui';
+
+const LibraryComponent = props => (
+    <TemplateLibrary
+        templates={props.templatesArray}
+        upload={props.uploadCTA}
+        import={props.importTemplate}
+        addTemp={props.addNewTemplate}
+        addToCont={props.addToContract}
+    />
+);
+```
+
+### Props
+
+- `templates` : An `array` which contains template objects with the following keys: `uir`, `name`, `version`, `description`.
+- `upload` : A function which calls for upload functionality within the app this component is embedded in.
+- `import` : A function which calls for import functionality within the app this component is embedded in.
+- `addTemp` : A function which adds a new blank template to the array of templates in the Redux store of the app this component is embedded in.
+- `addToCont` : A function which calls for adding the selected template to the Redux store in the app this component is embedded in. This will result in another component having use of its data.
+
+### Specifications
+
+This component is built to have the following dimensions:
+
+```
+height: 700px;
+width: 485px;
+```


### PR DESCRIPTION
# Issue #37 

### Changes
- Update project structure and badges
- Implement license file 
- Add markdown license file
- Implement readme for `ContractEditor` and `TemplateLibrary`
- Implement developer and contribution instructions

### Flags
- Markdown license file may be unnecessary. 
  - This was following @mttrbrts's commit here: https://github.com/accordproject/cicero/commit/93ff83e48691c913f5351389cf72b44cd8460593