### PR TITLE
test(TemplateLibrary): implement test and fix proptypes - I-35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@accordproject/cicero-core": {
-      "version": "0.12.3-20190515152902",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.12.3-20190515152902.tgz",
-      "integrity": "sha512-jNmljTsTaluIADpZF7WNKD1DPBSkeP++K3mGA3OCG8F2RxYLncDhuz7NsjnGAoQ0FcsBhDpgc5g+MazGOFMlxA==",
+      "version": "0.12.4-20190515234019",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.12.4-20190515234019.tgz",
+      "integrity": "sha512-u6XtabRQb/ChITJn/vCwy25nv+/ygNtCRJPdIRaT3k8ZyrsGNWpC3A9y0/zVUR2lsYrakdcFCcjkH3Pdji4LkQ==",
       "requires": {
         "@accordproject/ergo-compiler": "0.8.2",
         "axios": "0.18.0",

--- a/src/ClauseEditor/__snapshots__/index.test.js.snap
+++ b/src/ClauseEditor/__snapshots__/index.test.js.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ContractEditor /> on initialization renders page correctly 1`] = `
+exports[`<ClauseEditor /> on initialization renders page correctly 1`] = `
 <div>
   <MarkdownEditor
+    lockText={true}
+    markdown=""
     markdownMode={false}
     onChange={[Function]}
     plugins={Array []}

--- a/src/ClauseEditor/index.test.js
+++ b/src/ClauseEditor/index.test.js
@@ -2,12 +2,20 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import ContractEditor from './index';
+import ClauseEditor from './index';
 
-describe('<ContractEditor />', () => {
+const props = {
+  markdown: '',
+  onParse: () => 1,
+  onChange: () => 1,
+  lockText: true,
+  template: {},
+};
+
+describe('<ClauseEditor />', () => {
   describe('on initialization', () => {
     it('renders page correctly', () => {
-      const component = shallow(<ContractEditor />);
+      const component = shallow(<ClauseEditor {...props} />);
       const tree = toJson(component);
       expect(tree).toMatchSnapshot();
     });

--- a/src/ContractEditor/index.test.js
+++ b/src/ContractEditor/index.test.js
@@ -4,10 +4,18 @@ import toJson from 'enzyme-to-json';
 
 import ContractEditor from './index';
 
+const props = {
+  markdown: '',
+  onParse: () => 1,
+  onChange: () => 1,
+  lockText: true,
+  template: {},
+};
+
 describe('<ContractEditor />', () => {
   describe('on initialization', () => {
     it('renders page correctly', () => {
-      const component = shallow(<ContractEditor />);
+      const component = shallow(<ContractEditor {...props} />);
       const tree = toJson(component);
       expect(tree).toMatchSnapshot();
     });

--- a/src/ErrorLogger/index.test.js
+++ b/src/ErrorLogger/index.test.js
@@ -7,7 +7,7 @@ import ErrorLogger from './index';
 describe('<ErrorLogger />', () => {
   describe('on initialization', () => {
     it('renders page correctly', () => {
-      const component = shallow(<ErrorLogger />);
+      const component = shallow(<ErrorLogger errors={[]} />);
       const tree = toJson(component);
       expect(tree).toMatchSnapshot();
     });

--- a/src/TemplateLibrary/TemplateActions.js
+++ b/src/TemplateLibrary/TemplateActions.js
@@ -48,7 +48,7 @@ class TemplateActions extends React.Component {
     return (
         <ActionsContainer>
         <div>
-          <AddToContractBtn onClick={() => this.props.addToCont(this.props.uriKey)} >
+          <AddToContractBtn className="adToContractButton" onClick={() => this.props.addToCont(this.props.uriKey)} >
             <Icon name="plus" />
             Add to contract
           </AddToContractBtn>

--- a/src/TemplateLibrary/TemplateCard.js
+++ b/src/TemplateLibrary/TemplateCard.js
@@ -57,6 +57,7 @@ class TemplateCard extends React.Component {
               addToCont={this.props.addToCont}
               uriKey={template.uri}
               handleViewDetails={this.props.handleViewTemplate}
+              className="templateAction"
             />
         </CardContainer>
     );

--- a/src/TemplateLibrary/__snapshots__/index.test.js.snap
+++ b/src/TemplateLibrary/__snapshots__/index.test.js.snap
@@ -15,6 +15,7 @@ exports[`<TemplateLibrary /> on initialization renders page correctly 1`] = `
         placeholder="Search..."
       />
       <Styled(Button)
+        className="addTemplateButton"
         color="blue"
         content="New Clause Template"
         fluid={true}
@@ -22,7 +23,80 @@ exports[`<TemplateLibrary /> on initialization renders page correctly 1`] = `
         id="addClauseBtn"
       />
     </styled.div>
-    <Styled(CardGroup) />
+    <Styled(CardGroup)>
+      <TemplateCard
+        className="templateCard"
+        key="ap://acceptance-of-delivery@0.11.0#311de48109cce10e6b2e33ef183ccce121886d0b76754d649d5054d1084f93cd"
+        template={
+          Object {
+            "description": "This clause allows the receiver of goods to inspect them for a given time period after delivery.",
+            "name": "acceptance-of-delivery",
+            "uri": "ap://acceptance-of-delivery@0.11.0#311de48109cce10e6b2e33ef183ccce121886d0b76754d649d5054d1084f93cd",
+            "version": "0.11.0",
+          }
+        }
+      />
+      <TemplateCard
+        className="templateCard"
+        key="ap://car-rental-tr@0.8.0#1d6de2328745fe4bae726e0fb887fee6d3fbd00b3d717e30e38dc7bffd7222fa"
+        template={
+          Object {
+            "description": "a Simple Car Rental Contract in Turkish Language",
+            "name": "car-rental-tr",
+            "uri": "ap://car-rental-tr@0.8.0#1d6de2328745fe4bae726e0fb887fee6d3fbd00b3d717e30e38dc7bffd7222fa",
+            "version": "0.8.0",
+          }
+        }
+      />
+      <TemplateCard
+        className="templateCard"
+        key="ap://copyright-license@0.12.0#55d73ab5dacc642d8a7cd0bc95c7da5580bd031e00b955616837abd50be08b6b"
+        template={
+          Object {
+            "description": "This clause is a copyright license agreement.",
+            "name": "copyright-license",
+            "uri": "ap://copyright-license@0.12.0#55d73ab5dacc642d8a7cd0bc95c7da5580bd031e00b955616837abd50be08b6b",
+            "version": "0.12.0",
+          }
+        }
+      />
+      <TemplateCard
+        className="templateCard"
+        key="ap://demandforecast@0.11.0#ac252106feb1f685f5ecceb12b967bb8210ca5283660b5bf72aeb5b397342f87"
+        template={
+          Object {
+            "description": "A sample demandforecast clause.",
+            "name": "demandforecast",
+            "uri": "ap://demandforecast@0.11.0#ac252106feb1f685f5ecceb12b967bb8210ca5283660b5bf72aeb5b397342f87",
+            "version": "0.11.0",
+          }
+        }
+      />
+      <TemplateCard
+        className="templateCard"
+        key="ap://docusign-connect@0.5.0#4b44811f4f3e4899c026c35f4180d6c555f9101e8fcca35a13ad09aa2e28b7f7"
+        template={
+          Object {
+            "description": "Counts events from DocuSign connect with a given envelope status.",
+            "name": "docusign-connect",
+            "uri": "ap://docusign-connect@0.5.0#4b44811f4f3e4899c026c35f4180d6c555f9101e8fcca35a13ad09aa2e28b7f7",
+            "version": "0.5.0",
+          }
+        }
+      />
+      <TemplateCard
+        className="templateCard"
+        key="ap://eat-apples@0.8.0#5d04f0bb8698e1e7565e496aa97beb055b1f3e7fb353d0b0447aeaac59729ed2"
+        template={
+          Object {
+            "description": "This is a clause enforcing healthy eating habits in employees.",
+            "name": "eat-apples",
+            "uri": "ap://eat-apples@0.8.0#5d04f0bb8698e1e7565e496aa97beb055b1f3e7fb353d0b0447aeaac59729ed2",
+            "version": "0.8.0",
+          }
+        }
+      />
+    </Styled(CardGroup)>
   </styled.div>
 </div>
 `;

--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -113,6 +113,7 @@ class TemplateLibraryComponent extends React.PureComponent {
             && <UploadImport
               onClick={this.props.import}
               href="javascript:void(0);"
+              className="importButton"
               >
               Import from VS Code
             </UploadImport>}
@@ -120,6 +121,7 @@ class TemplateLibraryComponent extends React.PureComponent {
             && <UploadImport
               onClick={this.props.upload}
               href="javascript:void(0);"
+              className="uploadButton"
               >
               Upload CTA file
             </UploadImport>}
@@ -133,6 +135,7 @@ class TemplateLibraryComponent extends React.PureComponent {
               icon="plus"
               id="addClauseBtn"
               onClick={this.props.addTemp}
+              className="addTemplateButton"
             />
           </Functionality>
           <TemplateCards>
@@ -143,6 +146,7 @@ class TemplateLibraryComponent extends React.PureComponent {
                 addToCont={this.props.addToCont}
                 template={t}
                 handleViewTemplate={this.handleViewTemplate}
+                className="templateCard"
               />
             ))
           }

--- a/src/TemplateLibrary/index.test.js
+++ b/src/TemplateLibrary/index.test.js
@@ -2,14 +2,93 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
+import TemplateCard from './TemplateCard';
 import TemplateLibrary from './index';
+
+const templateArray = [
+  {
+    description: 'This clause allows the receiver of goods to inspect them for a given time period after delivery.',
+    name: 'acceptance-of-delivery',
+    uri: 'ap://acceptance-of-delivery@0.11.0#311de48109cce10e6b2e33ef183ccce121886d0b76754d649d5054d1084f93cd',
+    version: '0.11.0'
+  },
+  {
+    description: 'a Simple Car Rental Contract in Turkish Language',
+    name: 'car-rental-tr',
+    uri: 'ap://car-rental-tr@0.8.0#1d6de2328745fe4bae726e0fb887fee6d3fbd00b3d717e30e38dc7bffd7222fa',
+    version: '0.8.0'
+  },
+  {
+    description: 'This clause is a copyright license agreement.',
+    name: 'copyright-license',
+    uri: 'ap://copyright-license@0.12.0#55d73ab5dacc642d8a7cd0bc95c7da5580bd031e00b955616837abd50be08b6b',
+    version: '0.12.0'
+  },
+  {
+    description: 'A sample demandforecast clause.',
+    name: 'demandforecast',
+    uri: 'ap://demandforecast@0.11.0#ac252106feb1f685f5ecceb12b967bb8210ca5283660b5bf72aeb5b397342f87',
+    version: '0.11.0'
+  },
+  {
+    description: 'Counts events from DocuSign connect with a given envelope status.',
+    name: 'docusign-connect',
+    uri: 'ap://docusign-connect@0.5.0#4b44811f4f3e4899c026c35f4180d6c555f9101e8fcca35a13ad09aa2e28b7f7',
+    version: '0.5.0'
+  },
+  {
+    description: 'This is a clause enforcing healthy eating habits in employees.',
+    name: 'eat-apples',
+    uri: 'ap://eat-apples@0.8.0#5d04f0bb8698e1e7565e496aa97beb055b1f3e7fb353d0b0447aeaac59729ed2',
+    version: '0.8.0'
+  },
+];
+
 
 describe('<TemplateLibrary />', () => {
   describe('on initialization', () => {
     it('renders page correctly', () => {
-      const component = shallow(<TemplateLibrary />);
+      const component = shallow(<TemplateLibrary templates={templateArray} />);
       const tree = toJson(component);
       expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('runs functions passed into it', () => {
+    it('upload function runs', () => {
+      const mockUpload = jest.fn();
+      const component = shallow(<TemplateLibrary upload={mockUpload} />);
+      expect(component.find('.uploadButton').prop('onClick')).toEqual(mockUpload);
+      component.find('.uploadButton').simulate('click');
+      expect(mockUpload).toHaveBeenCalled();
+    });
+
+    it('import function runs', () => {
+      const mockImport = jest.fn();
+      const component = shallow(<TemplateLibrary import={mockImport} />);
+      expect(component.find('.importButton').prop('onClick')).toEqual(mockImport);
+      component.find('.importButton').simulate('click');
+      expect(mockImport).toHaveBeenCalled();
+    });
+
+    it('add Template function runs', () => {
+      const addNewTemplate = jest.fn();
+      const component = shallow(<TemplateLibrary addTemp={addNewTemplate} />);
+      expect(component.find('.addTemplateButton').prop('onClick')).toEqual(addNewTemplate);
+      component.find('.addTemplateButton').simulate('click');
+      expect(addNewTemplate).toHaveBeenCalled();
+    });
+
+    it('add To Contract function runs', () => {
+      const mockAddToCont = jest.fn();
+      const component = shallow(
+        <TemplateCard
+          key={templateArray[0].uri}
+          template={templateArray[0]}
+          addToCont={mockAddToCont}
+        />
+      );
+      expect(component.find('.templateAction').prop('addToCont')).toEqual(mockAddToCont);
     });
   });
 });

--- a/src/TemplateLoadingClauseEditor/__snapshots__/index.test.js.snap
+++ b/src/TemplateLoadingClauseEditor/__snapshots__/index.test.js.snap
@@ -2,18 +2,22 @@
 
 exports[`<ContractEditor /> on initialization renders page correctly 1`] = `
 <div>
-  <ClauseEditor />
+  <ClauseEditor
+    lockText={true}
+    markdown=""
+    onChange={[Function]}
+    onParse={[Function]}
+    template={Object {}}
+  />
   <Message
     attached="bottom"
     positive={true}
   >
     <Icon
       as="i"
-      loading={true}
-      name="circle notched"
+      name="check square"
     />
-    Loading 
-    ...
+    Loaded 
   </Message>
 </div>
 `;

--- a/src/TemplateLoadingClauseEditor/index.test.js
+++ b/src/TemplateLoadingClauseEditor/index.test.js
@@ -4,10 +4,18 @@ import toJson from 'enzyme-to-json';
 
 import ContractEditor from './index';
 
+const props = {
+  markdown: '',
+  onParse: () => 1,
+  onChange: () => 1,
+  lockText: true,
+  template: {},
+};
+
 describe('<ContractEditor />', () => {
   describe('on initialization', () => {
     it('renders page correctly', () => {
-      const component = shallow(<ContractEditor />);
+      const component = shallow(<ContractEditor {...props} />);
       const tree = toJson(component);
       expect(tree).toMatchSnapshot();
     });


### PR DESCRIPTION
# Issue #35 
## Related Issue #6 

### Changes
- Update snapshots
- Pass in props in tests for `PropType` warnings
- Add class names for testing
- Implement further tests for `TemplateLibrary`
- Corrected import name in `src/ClauseEditor/index.test.js`

### Flags
- Attempted `chai`, but abandoned when `effect` keyword was conflicting