### PR TITLE
fix(ClauseComponent): fix getting clauseId from attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5533,7 +5533,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5551,11 +5552,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5568,15 +5571,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5679,7 +5685,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5689,6 +5696,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5701,17 +5709,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5728,6 +5739,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5800,7 +5812,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5810,6 +5823,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5885,7 +5899,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5915,6 +5930,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5932,6 +5948,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5970,11 +5987,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/ContractEditor/index.js
+++ b/src/ContractEditor/index.js
@@ -14,8 +14,8 @@
 
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { SlateAsInputEditor } from '@accordproject/markdown-editor';
-import List from '@accordproject/markdown-editor/dist/plugins/list';
+import { SlateAsInputEditor, List } from '@accordproject/markdown-editor';
+
 import ClausePlugin from '../plugins/ClausePlugin';
 
 /**

--- a/src/plugins/ClausePlugin.js
+++ b/src/plugins/ClausePlugin.js
@@ -208,14 +208,14 @@ function ClausePlugin(customLoadTemplate, customParseClause) {
     const { node, children } = props;
 
     const nodeAttributes = node.data.get('attributes');
-    const { src, clauseId } = nodeAttributes;
+    const { src, clauseid } = nodeAttributes;
 
     if (src) {
       console.log(`handing over responsibility of loading: ${src}`);
       loadTemplateCallback(src.toString());
     }
 
-    return (<ClauseComponent templateUri={src} clauseId={clauseId} {...props}>{children}</ClauseComponent>);
+    return (<ClauseComponent templateUri={src} clauseId={clauseid} {...props}>{children}</ClauseComponent>);
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

### Changes
fix(ClauseComponent): fix getting clauseId from attributes
- the clauseId is converted to all lowercase when it is an attribute in the markdown, so we need to look for `clauseid` when getting it from attributes
- this fix will allow for the clause id to be rendered in the title of the clause component

