### PR TITLE
fix(TemplateLibrary): remove margins for imports - I62

### DIFF
--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -15,7 +15,6 @@ import { ImportComponent, UploadComponent, NewClauseComponent } from './Buttons'
 const TemplatesWrapper = styled.div`
   font-family: 'IBM Plex Sans', sans-serif;
   position: relative;
-  margin: 16px 16px;
   max-width: 355px;
 
   display: grid;


### PR DESCRIPTION
# Issue #62 
Correction to styling for importing to a third party. Was unable to `npm link` prior to #66.

### Changes
- Remove unnecessary margins

### Flags
- Template Studio v2 will need to use the latest `npm` version, which will not be an incremented pre-release.

### Related Issues
- Pull Request #66
