### PR TITLE
chore(*): update markdown-editor version and update propTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -188,9 +188,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.1.tgz",
-      "integrity": "sha512-UcC7gVpvh4H5Mn/xK2+8ffCAdMrxaVGCe4NbP+TM6fhgq0sgXU/C2BLqms3wWybrXvLV48/My36+Asz3IwyyRg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.4.tgz",
+      "integrity": "sha512-rLfzjc40s4CaneYiAOoj4UTpQ3xPIrBw4KFXnVxhgJdi2LMtajOjJs4UAxRJ8ZzjBwuH9GX+nSo7VUb2M2H/Bw==",
       "requires": {
         "commonmark": "^0.29.0",
         "css-loader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.13.0",
-    "@accordproject/markdown-editor": "^0.5.1",
+    "@accordproject/markdown-editor": "^0.5.4",
     "acorn": "5.1.2",
     "doctrine": "3.0.0",
     "lodash": "^4.17.11",

--- a/src/ClauseEditor/index.js
+++ b/src/ClauseEditor/index.js
@@ -95,19 +95,24 @@ ClauseEditor.propTypes = {
   value: PropTypes.object.isRequired,
 
   /**
-   * Callback when parsing is completed
-   */
-  onParse: PropTypes.func.isRequired,
-
-  /**
    * Callback when contents of the editor changes
    */
   onChange: PropTypes.func.isRequired,
 
   /**
+   * A callback to load a template
+   */
+  loadTemplateObject: PropTypes.func,
+
+  /**
    * When true only the variables in the template are editable
    */
   lockText: PropTypes.bool.isRequired,
+
+  /**
+   * A callback to parse the contents of a clause
+   */
+  parseClause: PropTypes.func,
 
   /**
    * The Cicero template for the clause (Optional)

--- a/src/ContractEditor/index.js
+++ b/src/ContractEditor/index.js
@@ -105,12 +105,12 @@ ContractEditor.propTypes = {
   /**
    * A callback to load a template
    */
-  loadTemplateObject: PropTypes.func.isRequired,
+  loadTemplateObject: PropTypes.func,
 
   /**
    * A callback to parse the contents of a clause
    */
-  parseClause: PropTypes.func.isRequired,
+  parseClause: PropTypes.func,
 
   /**
    * An array of plugins into the underlying markdown-editor


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

### Changes
- update markdown-editor to v0.5.4
- update propTypes (`parseClause` and `loadTemplateObject` are not required because `ClausePlugin` uses default methods for these if nothing is passed in)
