### PR TITLE
feat(ErrorLogger): handle error navigation - I17

### DIFF
--- a/src/ErrorLogger/index.js
+++ b/src/ErrorLogger/index.js
@@ -26,14 +26,20 @@ const ErrorLogger = (props) => {
 
   const errorComponentGenerator = errors => errors
     .map(soloError => <styles.ErrorComponent
-        key={actions.keySwitchCase(soloError)}
-        onClick={handleClickSpecError}>
+        key={actions.keySwitchCase(soloError)}>
 
-      <styles.ArrowDiv expanded={specErrorVisible} />
-      <styles.ErrorFile>{actions.typeSwitchCase(soloError)}</styles.ErrorFile>
-      <styles.ErrorType>{actions.overalltypeSwitchCase(soloError).name}:</styles.ErrorType>
+      <styles.ArrowDiv expanded={specErrorVisible} onClick={handleClickSpecError}/>
 
-      <styles.ErrorShortMessage>
+      <styles.ErrorFile
+        onClick={() => console.log('soloError: ', soloError.clauseId)}>
+        {actions.typeSwitchCase(soloError)}
+      </styles.ErrorFile>
+
+      <styles.ErrorType onClick={handleClickSpecError}>
+        {actions.overalltypeSwitchCase(soloError).name}:
+      </styles.ErrorType>
+
+      <styles.ErrorShortMessage onClick={handleClickSpecError}>
         {actions.truncateMessage(actions.overalltypeSwitchCase(soloError).shortMessage)}
       </styles.ErrorShortMessage>
 

--- a/src/ErrorLogger/index.js
+++ b/src/ErrorLogger/index.js
@@ -5,7 +5,7 @@ import * as actions from './actions';
 import * as styles from './styles';
 
 const ErrorLogger = (props) => {
-  const { errors } = props;
+  const { errors, errorNav } = props;
 
   const [errorsVisible, setErrorsVisible] = useState(false);
   const [specErrorVisible, setspecErrorVisible] = useState(false);
@@ -29,9 +29,8 @@ const ErrorLogger = (props) => {
         key={actions.keySwitchCase(soloError)}>
 
       <styles.ArrowDiv expanded={specErrorVisible} onClick={handleClickSpecError}/>
-
       <styles.ErrorFile
-        onClick={() => console.log('soloError: ', soloError.clauseId)}>
+        onClick={() => errorNav(soloError)}>
         {actions.typeSwitchCase(soloError)}
       </styles.ErrorFile>
 
@@ -69,6 +68,7 @@ const ErrorLogger = (props) => {
 
 ErrorLogger.propTypes = {
   errors: PropTypes.array.isRequired,
+  errorNav: PropTypes.func,
 };
 
 export default ErrorLogger;

--- a/src/TemplateLibrary/TemplateCard.js
+++ b/src/TemplateLibrary/TemplateCard.js
@@ -56,6 +56,7 @@ class TemplateCard extends React.Component {
   */
   render() {
     const { libraryProps, template } = this.props;
+    const displayName = template.displayName ? template.displayName : template.name;
     return (
         <CardContainer fluid
           key={template.uri}
@@ -65,7 +66,7 @@ class TemplateCard extends React.Component {
             <Card.Content>
               <TemplateLogo src={template.icon} />
               <Title color={libraryProps.TEMPLATE_TITLE}>
-                {template.name}
+                {displayName}
                 <Version>v {template.version}</Version>
               </Title>
               <DescriptionContainer color={libraryProps.TEMPLATE_DESCRIPTION}>


### PR DESCRIPTION
# Issue #17 
Refactor and prepare `ErrorLogger` to be imported with functionality

### Changes
- Unrelated addition to `TemplateLibrary` to render `displayName` only if it exists
- Uses function passed from props to handle the individual clause the error refers to

### Flags
- A separate PR will be put in for the styling additions
- Future work is needed to clean up the functionality of clicking on different areas of errors

### Related Issues
- [TSv2 Issue 61](https://github.com/accordproject/template-studio-v2/issues/61)
