### PR TITLE
feat(ContractEditor): forward ref to SlateAsInputEditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.10.tgz",
-      "integrity": "sha512-ZbSufvOEDPros21y6sKAxYO04XxwAFsnKXX/Pi4FP4evRCOVx9RdEeqvIaeqzphmnJzh4V5uLtahgTYVpD0hmA==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.11.tgz",
+      "integrity": "sha512-oOna8bPvuaVa/WKV8ew2IRnS6/820RIQvHpKuXi28lfniwJi4uRhCYemp1WYExLm8RlY4yhKBTnvt229vriMKg==",
       "requires": {
         "commonmark": "^0.29.0",
         "css-loader": "^3.0.0",
@@ -5734,8 +5734,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5753,13 +5752,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5772,18 +5769,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5886,8 +5880,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5897,7 +5890,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5910,20 +5902,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5940,7 +5929,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6013,8 +6001,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6024,7 +6011,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6100,8 +6086,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6131,7 +6116,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6149,7 +6133,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6188,13 +6171,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.13.4",
-    "@accordproject/markdown-editor": "^0.5.10",
+    "@accordproject/markdown-editor": "^0.5.11",
     "acorn": "5.1.2",
     "doctrine": "3.0.0",
     "lodash": "^4.17.15",

--- a/src/ClauseEditor/__snapshots__/index.test.js.snap
+++ b/src/ClauseEditor/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<ClauseEditor /> on initialization renders page correctly 1`] = `
 <div>
-  <ContractEditor
+  <ForwardRef
     lockText={true}
     onChange={[Function]}
     showEditButton={true}

--- a/src/ContractEditor/index.js
+++ b/src/ContractEditor/index.js
@@ -57,7 +57,8 @@ const contractProps = {
  *
  * @param {*} props the properties for the component
  */
-const ContractEditor = (props) => {
+// eslint-disable-next-line react/display-name
+const ContractEditor = React.forwardRef((props, ref) => {
   const [plugins, setPlugins] = useState([]);
   useEffect(() => {
     setPlugins(
@@ -70,6 +71,7 @@ const ContractEditor = (props) => {
   }, [props.clauseProps, props.loadTemplateObject, props.parseClause, props.plugins]);
   return (
     plugins.length ? <SlateAsInputEditor
+    ref={ref}
     value={props.value || contractProps.value}
     onChange={props.onChange || contractProps.onChange}
     plugins={plugins}
@@ -77,7 +79,7 @@ const ContractEditor = (props) => {
     editorProps={props.editorProps}
   /> : null
   );
-};
+});
 /**
  * The property types for this component
  */


### PR DESCRIPTION
### Changes
feat(ContractEditor): forward ref to SlateAsInputEditor

### Related PRs
https://github.com/accordproject/markdown-editor/pull/76
