### PR TITLE
fix(Navigation): remove unnecessary grid in contracts

### DIFF
--- a/src/Navigation/styles.js
+++ b/src/Navigation/styles.js
@@ -54,7 +54,6 @@ export const ContractHeaders = styled.div`
     overflow-x: hidden;
     padding-top: 10px;
 
-    display: grid;
     grid-area: body;
 
     &::-webkit-scrollbar-track {


### PR DESCRIPTION
# No Issue
Remove unnecessary grid attribute causing spacing issues

### Changes
- Remove unnecessary grid attribute causing spacing issues

### Flags
N/A

### Related Issues
- Issue #91 
