### PR TITLE
style(*): adjut clause and text alignment - I128

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -57,9 +57,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.13.tgz",
-      "integrity": "sha512-RX7Qk0Rb6YZyx3Q2jSiz34aV75TL+ExxISthVodQgMvLo8IiA1xdE7W/AoJUIkanYheraAXXgb6kmHPrkLsoww==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.14.tgz",
+      "integrity": "sha512-uQ0CAICqH5AEimzQOJcLNUcvevCEFux6OTQNlLOWGQU/X/iL3ObirRFWRcj49irdq03qlfZywBEK1nfwrn7B+g==",
       "requires": {
         "commonmark": "^0.29.0",
         "css-loader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.13.4",
-    "@accordproject/markdown-editor": "^0.5.13",
+    "@accordproject/markdown-editor": "^0.5.14",
     "acorn": "5.1.2",
     "doctrine": "3.0.0",
     "lodash": "^4.17.15",

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import './index.css';
 
 export const ClauseWrapper = styled.div`
+  margin: 10px -10px;
   display: grid;
   grid-template-columns: 10px 375px 1fr 25px 25px 25px 10px;
   grid-template-rows: 11px 11px 1fr;
@@ -25,7 +26,7 @@ export const ClauseHeader = styled.div`
   background: linear-gradient(180deg, #FFFFFF 0%, #ECF0FA 100%);
   align-self: center;
   justify-self: start;
-  margin: 12px 0;
+  margin: 6px 0;
   padding: 3px;
   color: #939EBA;
   line-height: 14px;
@@ -36,7 +37,7 @@ export const ClauseHeader = styled.div`
 export const ClauseBody = styled.div`
   font-family: ${props => props.bodyfont || 'Graphik'};
   grid-area: sixteen / sixteen / twenty / twenty;
-  margin: 10px 0;
+  margin: 2px 0 10px;
   color: #141F3C;
   font-size: 1em;
   line-height: 22px;


### PR DESCRIPTION
# Issue #128 
Slight styling adjustments to align text in and out of a clause

### Changes
- Increment `markdown-editor` version
- Slight styling adjustments to align text in and out of a clause

### Flags
N/A

### Related Issues
N/A
