### PR TITLE
fix(ClausePlugin): use loadTemplateCallback in rewriteClause

### DIFF
--- a/src/plugins/ClausePlugin.js
+++ b/src/plugins/ClausePlugin.js
@@ -74,26 +74,6 @@ function ClausePlugin(customLoadTemplate, customParseClause, clauseProps) {
   }
 
   /**
-   * Rewrites the text of a clause to introduce variables
-   *
-   * @param {string} templateUri the URI of the template to load
-   * @param {string} clauseText the text of the clause (must be parseable)
-   */
-  async function rewriteClause(templateUri, clauseText) {
-    try {
-      const template = await loadTemplate(templateUri);
-      const clause = new Clause(template);
-      clause.parse(clauseText);
-      const variableText = clause.generateText({ wrapVariables: true });
-      console.log(variableText);
-      return Promise.resolve(variableText);
-    } catch (err) {
-      console.log(err);
-      return Promise.resolve(err);
-    }
-  }
-
-  /**
    * Called by the clause plugin into the contract editor
    * when we need to parse a clause
    */
@@ -114,6 +94,26 @@ function ClausePlugin(customLoadTemplate, customParseClause, clauseProps) {
 
   const loadTemplateCallback = customLoadTemplate || loadTemplate;
   const parseClauseCallback = customParseClause || parseClause;
+
+  /**
+   * Rewrites the text of a clause to introduce variables
+   *
+   * @param {string} templateUri the URI of the template to load
+   * @param {string} clauseText the text of the clause (must be parseable)
+   */
+  async function rewriteClause(templateUri, clauseText) {
+    try {
+      const template = await loadTemplateCallback(templateUri);
+      const clause = new Clause(template);
+      clause.parse(clauseText);
+      const variableText = clause.generateText({ wrapVariables: true });
+      console.log(variableText);
+      return Promise.resolve(variableText);
+    } catch (err) {
+      console.log(err);
+      return Promise.resolve(err);
+    }
+  }
 
   /**
    * Adds an annotation to the editor


### PR DESCRIPTION
fix(ClausePlugin): use loadTemplateCallback in rewriteClause
Signed-off-by: Diana Lease <dianarlease@gmail.com>

By using `loadTemplateCallback`, we will use the custom load template function if one is passed in before falling back to the `loadTemplate` method defined in this plugin.