### PR TITLE
feat(ClausePlugin): handle paste functionality with clauses - I134

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.14.tgz",
-      "integrity": "sha512-uQ0CAICqH5AEimzQOJcLNUcvevCEFux6OTQNlLOWGQU/X/iL3ObirRFWRcj49irdq03qlfZywBEK1nfwrn7B+g==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.15.tgz",
+      "integrity": "sha512-Psawwcqt94fAs/iZ9RBUCTMXlA0ugRuAE4zXaAJT6mCrg+1mtGVxAIGdX5nlhBGEN9equrmHdO4sNL5zHhj0Wg==",
       "requires": {
         "commonmark": "^0.29.0",
         "css-loader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-dom": "^16.8.6",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.87.2",
-    "slate": "^0.47.4"
+    "slate": "^0.47.4",
+    "slate-react": "^0.22.8"
   },
   "peerDependencies": {
     "react": "16.x",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.13.4",
-    "@accordproject/markdown-editor": "^0.5.14",
+    "@accordproject/markdown-editor": "^0.5.15",
     "acorn": "5.1.2",
     "doctrine": "3.0.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
# Issue #134
Create new `uuid` for a clause that was copy/pasted in conjunction with [this PR in `markdown-editor`](https://github.com/accordproject/markdown-editor/pull/89)

### Changes
- On a paste event, we take the `Document` on the event and make it mutable in order to change the `clauseid` to a `uuid` and revert everything to immutable
- Abstracted clause specific logic out of `@accordproject/markdown-editor`

### Flags
- Further issues should consider:

  - Handling different `transfer.type` situations
    - Editor instance (Slate) to another editor instance (Slate)
    - Raw `HTML` (Chrome to VSCode to Chrome)
    - Editor instance (Slate) to Google Docs and back (recognize `<clause>` formatting)

  - Ensure `onPaste` handlers are not doubling up work for any `transfer.type` cases
    - `@accordproject/cicero-ui/src/plugins/ClausePlugin`
    - `@accordproject/markdown-editor/src/SlateAsInputEditor`

  - What `fragment.type` results when copying pasting from one editor to another instance of an editor?
    - `fragment` as a `transfer.type` is a Slate DOM block fragment, not `HTML` anymore, so copying and pasting from the same editor into itself should be a fragment
    - However, copying pasting from one editor to another instance of an editor may result in `HTML` or `fragment`, needs experimentation

  - Preserve formatting, if `H1` in `HTML`, we should be preserving the formatting
    - Slate has a mechanism for mapping from `HTML` tags to Slate blocks [here](https://github.com/accordproject/markdown-editor/blob/master/src/html/fromHTML.js)

- Further work is needed in the redux store of TSv2, showcased here where the new `uuid`'s placed onto the `clauses` are not represented in the store, and moreover the *extra* pasted clause does not appear at all:

DOM:
<img width="1680" alt="Screen Shot 2019-08-30 at 3 32 49 PM" src="https://user-images.githubusercontent.com/36460856/64048218-1f4c8f00-cb3f-11e9-89f1-bfbc9890c66d.png">
Store:
<img width="1680" alt="Screen Shot 2019-08-30 at 3 33 08 PM" src="https://user-images.githubusercontent.com/36460856/64048223-22e01600-cb3f-11e9-99ab-e58394194647.png">


### Related Issues
- [TSv2 Issue 85](https://github.com/accordproject/template-studio-v2/issues/85)
- [Markdown Editor Issue 88](https://github.com/accordproject/markdown-editor/issues/88)