### PR TITLE
feat(plugins): parse clauses on paste - I141

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -57,9 +57,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.15.tgz",
-      "integrity": "sha512-Psawwcqt94fAs/iZ9RBUCTMXlA0ugRuAE4zXaAJT6mCrg+1mtGVxAIGdX5nlhBGEN9equrmHdO4sNL5zHhj0Wg==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.16.tgz",
+      "integrity": "sha512-y2kCm73YJewDROh2lWjsqLdW7ym0RydRNIO6SLG0t67hl+UIO6VfztthwHpHkW9I6EJA85ltmtIind9vr7VRgA==",
       "requires": {
         "commonmark": "^0.29.0",
         "css-loader": "^3.0.0",

--- a/src/plugins/ClausePlugin.js
+++ b/src/plugins/ClausePlugin.js
@@ -325,9 +325,24 @@ function ClausePlugin(customLoadTemplate, customParseClause, customPasteClause, 
       parseText,
       src,
     };
+
     // we only re-parse and modify the value if the text has changed
     if (!annotationExists(editor, annotation)) {
       replaceAnnotations(replaceAnnotationObject);
+      removeParseAnnotations(editor, clauseid);
+
+      parseClauseCallback(src, parseText, clauseid)
+        .then((parseResult) => {
+          console.log(parseResult);
+          annotation.type = 'parseResult';
+          annotation.data = parseResult;
+          addAnnotation(editor, annotation);
+        })
+        .catch((error) => {
+          annotation.type = 'parseError';
+          annotation.data = { error };
+          addAnnotation(editor, annotation);
+        });
     }
     return next();
   }

--- a/src/plugins/ClausePlugin.js
+++ b/src/plugins/ClausePlugin.js
@@ -261,7 +261,7 @@ function ClausePlugin(customLoadTemplate, customParseClause, customPasteClause, 
     if (isEditable(editor.value, 'paste')) {
       const transfer = getEventTransfer(event);
 
-      // maybe keep track of all the things that jsut got pasted
+      // keep track of all the things that just got pasted
       const clausesToParse = [];
 
       if (transfer.type === 'fragment') {


### PR DESCRIPTION
# Issue #141
Parse an add any necessary annotations to clauses as they are pasted

### Changes
- Adapt `removeParseAnnotations` function to only remove annotations from the specific clause in question
- `parsePastedClauses` mimics `onChange`, but is run for each clause within a pasted fragment
- The hash for the annotation is adapted to account for a `clauseId` for better stability in differentiating clauses' annotations

### Flags
- Current issue is that the annotation is not added to display red in the editor when a clause with parse errors is copy/pasted. When clicking inside the pasted clause, the annotation is immediately displayed.

### Related Issues
- Issue #134
