### PR TITLE
fix(*): split webpack config to handle local dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6815,9 +6815,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
+      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "webpack-dev-server --config webpack.config.js --mode development --watch ",
+    "dev": "webpack-dev-server --mode development --config webpack.config.js",
     "transpile": "babel src -d dist --copy-files",
     "prepublishOnly": "npm run transpile",
-    "build": "webpack --config webpack.config.js --mode production",
+    "build": "webpack --mode production --config webpack.config.prod.js",
+    "build:dev": "webpack --config webpack.config.js",
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore ./src",
     "test": "jest",
     "test:watch": "npm test -- --watch",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.13.4",
-    "@accordproject/markdown-editor": "^0.5.15",
+    "@accordproject/markdown-editor": "^0.5.16",
     "acorn": "5.1.2",
     "doctrine": "3.0.0",
     "lodash": "^4.17.15",

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -5,6 +5,13 @@ const path = require('path');
 
 module.exports = {
   entry: './demo/src/index.js',
+  externals: {
+    'styled-components': {
+      commonjs: 'styled-components',
+      commonjs2: 'styled-components',
+      amd: 'styled-components',
+    },
+  },
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'demo/dist'),


### PR DESCRIPTION
# Markdown Editor Issue [#90](https://github.com/accordproject/markdown-editor/issues/90)
Address outstanding issue of `webpack` from [`markdown-editor` PR #86](https://github.com/accordproject/markdown-editor/pull/86) not working for local development, brought up by @KaustubhD and @Anisha1234

### Changes
- Split `webpack` configs and `npm` scripts to handle development and production environments

### Flags
- Instructions in the `README` will need further updating and polishing
- Reviewers should ensure testing this in dev (isolated) and also in TSv2 (`npm link`)

### Related Issues
- [`markdown-editor` PR #86](https://github.com/accordproject/markdown-editor/pull/86)
- [`markdown-editor` Issue #85](https://github.com/accordproject/markdown-editor/issues/85)
- [`markdown-editor` Issue #90](https://github.com/accordproject/markdown-editor/issues/90)