### PR TITLE
fix(ErrorLogger): typo in errors check const name

### DIFF
--- a/src/ErrorLogger/actions.js
+++ b/src/ErrorLogger/actions.js
@@ -37,7 +37,7 @@ export const errorsExist = errors => gtZero(errors.length);
 
 export const errorArrayLength = errors => (errorsExist(errors) ? errors.length : 'No');
 
-export const isMultpleErrors = errors => ((errors.length > 1) ? 'Errors' : 'Error');
+export const isMultipleErrors = errors => ((errors.length > 1) ? 'Errors' : 'Error');
 
 export const truncateMessage = string => ((string.length > 200)
   ? `${string.substring(0, 200)}...` : string);

--- a/src/ErrorLogger/index.js
+++ b/src/ErrorLogger/index.js
@@ -67,7 +67,7 @@ const ErrorLogger = (props) => {
       <SC.ErrorsHeader {...headerProps} >
         {ACT.gtZero(errors.length)
           && <SC.ErrorSymbol {...symbolProps} />}
-        {ACT.errorArrayLength(errors)} {ACT.isMultpleErrors(errors)}
+        {ACT.errorArrayLength(errors)} {ACT.isMultipleErrors(errors)}
         <SC.ErrorBarArrow {...barArrowProps} />
       </SC.ErrorsHeader>
     </div>


### PR DESCRIPTION
Small typo fix in code

### Changes
Change **isMultpleErrors** to **isMultipleErrors**



