### PR TITLE
feat(components) add header tooltip - I120

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5757,7 +5757,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5775,11 +5776,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5792,15 +5795,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5903,7 +5909,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5913,6 +5920,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5925,17 +5933,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5952,6 +5963,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6024,7 +6036,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6034,6 +6047,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6109,7 +6123,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6139,6 +6154,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6156,6 +6172,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6194,11 +6211,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/components/ClauseComponent.js
+++ b/src/components/ClauseComponent.js
@@ -10,7 +10,7 @@ import * as S from './styles';
 import * as deleteIcon from '../icons/trash';
 
 /* Actions */
-import headerGenerator from './actions';
+import { titleGenerator, headerGenerator } from './actions';
 
 const deleteIconProps = {
   'aria-label': deleteIcon.type,
@@ -27,10 +27,14 @@ const deleteIconProps = {
 function ClauseComponent(props) {
   const clauseProps = props.clauseProps || Object.create(null);
   const [hovering, setHovering] = useState(false);
+  const [hoveringHeader, setHoveringHeader] = useState(false);
 
   const errorsComponent = props.errors
     ? <Segment contentEditable={false} attached raised>{props.errors}</Segment>
     : null;
+
+  const title = titleGenerator(props.templateUri);
+  const header = headerGenerator(props.templateUri, clauseProps.HEADER_TITLE);
 
   return (
     <S.ClauseWrapper
@@ -49,7 +53,19 @@ function ClauseComponent(props) {
         headercolor={clauseProps.HEADER_COLOR}
         headerbg={clauseProps.CLAUSE_BACKGROUND}
       >
-        {headerGenerator(props.templateUri, clauseProps.HEADER_TITLE)}
+        {(hoveringHeader && header.length > 54)
+          && <S.HeaderToolTipWrapper>
+            <S.HeaderToolTip>
+              {title}
+            </S.HeaderToolTip>
+          </S.HeaderToolTipWrapper>
+        }
+        <S.HeaderToolTipText
+          onMouseEnter={() => setHoveringHeader(true)}
+          onMouseLeave={() => setHoveringHeader(false)}
+        >
+          {header}
+        </S.HeaderToolTipText>
       </S.ClauseHeader>
       <S.DeleteWrapper
         currentHover={hovering}

--- a/src/components/ClauseComponent.js
+++ b/src/components/ClauseComponent.js
@@ -56,7 +56,7 @@ function ClauseComponent(props) {
         {(hoveringHeader && header.length > 54)
           && <S.HeaderToolTipWrapper>
             <S.HeaderToolTip>
-              {title}
+              {title + clauseProps.HEADER_TITLE}
             </S.HeaderToolTip>
           </S.HeaderToolTipWrapper>
         }

--- a/src/components/__snapshots__/index.test.js.snap
+++ b/src/components/__snapshots__/index.test.js.snap
@@ -10,7 +10,12 @@ exports[`<ClauseComponent /> on initialization renders component correctly 1`] =
   <styled.div
     currentHover={false}
   >
-    ACCEPTANCE OF DELIVERYundefined
+    <styled.span
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      ACCEPTANCE OF DELIVERYundefined
+    </styled.span>
   </styled.div>
   <styled.div
     currentHover={false}

--- a/src/components/actions.js
+++ b/src/components/actions.js
@@ -4,18 +4,16 @@ const titleReducer = input => input.slice((titleStart(input) + 1), titleEnd(inpu
 const titleSpacer = input => input.replace(/-/g, ' ');
 const titleCaps = input => input.toUpperCase();
 
-const titleGenerator = (input) => {
+export const titleGenerator = (input) => {
   const reducedTitle = titleReducer(input);
   const spacedTitle = titleSpacer(reducedTitle);
   const finalTitle = titleCaps(spacedTitle);
   return finalTitle;
 };
 
-const headerGenerator = (templateTitle, inputTitle) => {
+export const headerGenerator = (templateTitle, inputTitle) => {
   const title = titleGenerator(templateTitle);
   const header = (title + inputTitle);
   const truncatedTitle = ((header.length > 54) ? (`${header.slice(0, 54)}...`) : header);
   return truncatedTitle;
 };
-
-export default headerGenerator;

--- a/src/components/index.test.js
+++ b/src/components/index.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import headerGenerator from './actions';
+import { headerGenerator } from './actions';
 import ClauseComponent from './ClauseComponent';
 
 const templateTitle = 'ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f';

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import './index.css';
 
 export const ClauseWrapper = styled.div`
+  position: relative;
   margin: 10px -10px;
   display: grid;
   grid-template-columns: 10px 375px 1fr 25px 25px 25px 10px;
@@ -70,4 +71,28 @@ export const ClauseAdd = styled.svg`
   &:hover {
     fill: #FFFFFF;
   }
+`;
+
+
+export const HeaderToolTipWrapper = styled.div`
+  position: absolute;
+  top: -25px;
+`;
+
+export const HeaderToolTip = styled.div`
+  background-color: #141f3a;
+  border-radius: 3px;
+  padding: 5px;
+  :after {
+    content: " ";
+    position: absolute;
+    top: 100%;
+    left: 5px;
+    border-width: 4px;
+    border-style: solid;
+    border-color: #141f3a transparent transparent transparent;
+  }
+`;
+
+export const HeaderToolTipText = styled.span`
 `;


### PR DESCRIPTION
# Issue #120 
hovering over clause template header title will pop up a tooltip if header has been truncated.

### Changes
- use named imports instead of default from `actions` to utilize `titleGenerator` function to display title on tooltip.
- create state for hover effect.
- tooltip pops up with full title if header is truncated (> 54 characters in length) and hovered over.
- Images following, hovering when header title is not truncated:
<img width="576" alt="Screen Shot 2019-10-06 at 12 14 08 AM" src="https://user-images.githubusercontent.com/17282870/66272058-8807e500-e82a-11e9-9757-998f2421ec8e.png">

- hovering when header title is truncated:

<img width="586" alt="Screen Shot 2019-10-06 at 11 13 54 AM" src="https://user-images.githubusercontent.com/17282870/66272067-9ce47880-e82a-11e9-87cd-baf3088002d9.png">


### Flags
- 

### Related Issues
- Issue #121 
- Issue #120 
