### PR TITLE
feat(ErrorLogger): accept object instead array - I137

### DIFF
--- a/src/ErrorLogger/Error.js
+++ b/src/ErrorLogger/Error.js
@@ -10,7 +10,6 @@ import * as SC from './styles';
 
 const ErrorComponent = (props) => {
   const { error, errorProps, errorNav } = props;
-
   const [specErrorVisible, setspecErrorVisible] = useState(false);
 
   const handleClickSpecError = () => {

--- a/src/ErrorLogger/README.md
+++ b/src/ErrorLogger/README.md
@@ -38,7 +38,7 @@ const ErrorContainer = props => (
 
 #### Expected to be Provided
 
-- `errors` : An `array` which contains error objects.
+- `errors` : An `object` with unique key and error's data.
 
 #### Require Provision
 

--- a/src/ErrorLogger/actions.js
+++ b/src/ErrorLogger/actions.js
@@ -33,11 +33,11 @@ export const overalltypeSwitchCase = (input) => {
   }
 };
 
-export const errorsExist = errors => gtZero(errors.length);
+export const errorsExist = errors => gtZero(Object.keys(errors).length);
 
-export const errorArrayLength = errors => (errorsExist(errors) ? errors.length : 'No');
+export const errorArrayLength = errors => (errorsExist(errors) ? Object.keys(errors).length : 'No');
 
-export const isMultipleErrors = errors => ((errors.length > 1) ? 'Errors' : 'Error');
+export const isMultipleErrors = errors => ((Object.keys(errors).length > 1) ? 'Errors' : 'Error');
 
 export const truncateMessage = string => ((string.length > 200)
   ? `${string.substring(0, 200)}...` : string);

--- a/src/ErrorLogger/index.js
+++ b/src/ErrorLogger/index.js
@@ -13,12 +13,13 @@ import ErrorComponent from './Error';
 
 const ErrorLogger = (props) => {
   const { errors, errorNav } = props;
+  const errorLength = Object.keys(errors).length;
   const errorsProps = props.errorsProps || Object.create(null);
 
   const [errorsVisible, setErrorsVisible] = useState(false);
 
   const handleClickErrorsBar = () => {
-    if (ACT.gtZero(errors.length)) { setErrorsVisible(!errorsVisible); }
+    if (ACT.gtZero(errorLength)) { setErrorsVisible(!errorsVisible); }
   };
 
   const headerProps = {
@@ -50,12 +51,12 @@ const ErrorLogger = (props) => {
     size: 'small'
   };
 
-  const errorComponentGenerator = errors => errors
-    .map(soloError => <ErrorComponent
+  const errorComponentGenerator = errors => Object.values(errors)
+    .map(errorValue => <ErrorComponent
       errorProps={errorsProps}
-      error={soloError}
+      error={errorValue}
       errorNav={errorNav}
-      key={ACT.keySwitchCase(soloError)} />);
+      key={ACT.keySwitchCase(errorValue)} />);
 
   return (
     <div>
@@ -65,7 +66,7 @@ const ErrorLogger = (props) => {
           </SC.ErrorDisplay>}
 
       <SC.ErrorsHeader {...headerProps} >
-        {ACT.gtZero(errors.length)
+        {ACT.gtZero(errorLength)
           && <SC.ErrorSymbol {...symbolProps} />}
         {ACT.errorArrayLength(errors)} {ACT.isMultipleErrors(errors)}
         <SC.ErrorBarArrow {...barArrowProps} />
@@ -75,7 +76,7 @@ const ErrorLogger = (props) => {
 };
 
 ErrorLogger.propTypes = {
-  errors: PropTypes.array.isRequired,
+  errors: PropTypes.object.isRequired,
   errorNav: PropTypes.func,
   errorsProps: PropTypes.shape({
     ERRORS_HEADER_BACKGROUND: PropTypes.string,

--- a/src/ErrorLogger/index.test.js
+++ b/src/ErrorLogger/index.test.js
@@ -5,35 +5,39 @@ import toJson from 'enzyme-to-json';
 import ErrorLogger from './index';
 
 const parseError1 = {
-  clauseId: 'b28f32b2-57d9-41e1-b871-03c9faa75b6e',
-  parseError: {
-    fileLocation: {
-      end: {
-        endColumn: 2,
-        line: 1
+  'b28f32b2-57d9-41e1-b871-03c9faa75b6e': {
+    clauseId: 'b28f32b2-57d9-41e1-b871-03c9faa75b6e',
+    parseError: {
+      fileLocation: {
+        end: {
+          endColumn: 2,
+          line: 1
+        },
+        start: {
+          column: 1
+        }
       },
-      start: {
-        column: 1
-      },
-    },
-    component: 'cicero-core',
-    fileName: undefined,
-    name: 'ParseException',
-    shortMessage: '"invalid syntax at line 1 col 1:↵↵  a  Acceptance of Delivery. "Party A" will be deemed to have completed its delivery obligations if in "Party B"\'s opinion, the "Widgets" satisfies the Acceptance Criteria, and "Party B" notifies "Party A" in writing that it is accepting the "Widgets".↵  ^↵Unexpected "a"↵"',
-    message: '"invalid syntax at line 1 col 1:↵↵  a  Acceptance of Delivery. "Party A" will be deemed to have completed its delivery obligations if in "Party B"\'s opinion, the "Widgets" satisfies the Acceptance Criteria, and "Party B" notifies "Party A" in writing that it is accepting the "Widgets".↵  ^↵Unexpected "a"↵"'
+      component: 'cicero-core',
+      fileName: undefined,
+      name: 'ParseException',
+      shortMessage:
+        '"invalid syntax at line 1 col 1:↵↵  a  Acceptance of Delivery. "Party A" will be deemed to have completed its delivery obligations if in "Party B"\'s opinion, the "Widgets" satisfies the Acceptance Criteria, and "Party B" notifies "Party A" in writing that it is accepting the "Widgets".↵  ^↵Unexpected "a"↵"',
+      message:
+        '"invalid syntax at line 1 col 1:↵↵  a  Acceptance of Delivery. "Party A" will be deemed to have completed its delivery obligations if in "Party B"\'s opinion, the "Widgets" satisfies the Acceptance Criteria, and "Party B" notifies "Party A" in writing that it is accepting the "Widgets".↵  ^↵Unexpected "a"↵"'
+    }
   }
 };
 
 describe('<ErrorLogger />', () => {
   describe('on initialization', () => {
     it('renders page correctly with errors', () => {
-      const component = shallow(<ErrorLogger errors={[parseError1]} />);
+      const component = shallow(<ErrorLogger errors={parseError1} />);
       const tree = toJson(component);
       expect(tree).toMatchSnapshot();
     });
 
     it('renders page correctly without errors', () => {
-      const component = shallow(<ErrorLogger errors={[]} />);
+      const component = shallow(<ErrorLogger errors={{}} />);
       const tree = toJson(component);
       expect(tree).toMatchSnapshot();
     });
@@ -41,7 +45,7 @@ describe('<ErrorLogger />', () => {
 
   describe('renders conditional to errors', () => {
     it('with errors existing', () => {
-      const component = shallow(<ErrorLogger errors={[parseError1]} />);
+      const component = shallow(<ErrorLogger errors={parseError1} />);
       expect(component.find('#ErrorComponentHeader').exists()).toBeTruthy();
 
       component.find('#ErrorComponentHeader').simulate('click');
@@ -50,7 +54,7 @@ describe('<ErrorLogger />', () => {
     });
 
     it('without errors existing', () => {
-      const component = shallow(<ErrorLogger errors={[]} />);
+      const component = shallow(<ErrorLogger errors={{}} />);
       expect(component.find('#ErrorComponentHeader').exists()).toBeTruthy();
       expect(component.find('#ErrorComponentDisplay').exists()).toBe(false);
 


### PR DESCRIPTION
Signed-off-by: Pawel -Muody- Kochanek <pawel.kochanek@gmail.com>

# Issue #137 
ErrorLogger was accepting an array of objects and there was possible issue with duplicate errors. The task was to change array to object.

### Changes
- change 'errorComponentGenerator' function. Right now it's mapping over keys of error object, not array as before.
- change propTypes, not errors are required object, not array
- change error value in tests
- in action.js, instead errors.length, we use Object.keys(errors).length.

### Flags
- There were not many changes I made, main change was iteration over Object.keys instead of errors array. The rest was written such a way I just made some fine tuning. Also in tests I just change the errors object structure. After that, all errors passed.