### PR TITLE
chore(gitignore): add thumbs.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log*
 /log
 
 .DS_Store
+thumbs.db


### PR DESCRIPTION
### Changes

`thumbs.db` is a windows directory cache file which sometimes gets pushed to repos, comes in commits, and can trouble other users. Now windows users can send PRs without having to worry about `thumbs.db`.

