### PR TITLE
feat(TemplateLibrary): add semver filtering - I180

### DIFF
--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { satisfies } from 'semver';
 
 /* React */
 import React, { useState } from 'react';
@@ -95,12 +96,20 @@ const TemplateLibraryComponent = (props) => {
 
   const filterTemplates = (templates) => {
     let filteredTemplates = templates;
+
     if (query.length) {
       const regex = new RegExp(query, 'i');
       filteredTemplates = _.filter(filteredTemplates, t => (
         t.name.match(regex) || t.uri.match(regex)
       ));
     }
+
+    if (props.semver && props.semver.length) {
+      filteredTemplates = filteredTemplates.filter(t => (
+        satisfies(t.version, props.semver)
+      ));
+    }
+
     return filteredTemplates;
   };
 

--- a/src/TemplateLibrary/index.test.js
+++ b/src/TemplateLibrary/index.test.js
@@ -105,4 +105,16 @@ describe('<TemplateLibrary />', () => {
       expect(component.find('.templateAction').prop('addToCont')).toEqual(mockAddToCont);
     });
   });
+
+  describe('version filtering', () => {
+    it('filters based on semver', () => {
+      const component = shallow(<TemplateLibrary libraryProps={libraryProps} {...propInput} semver=">= 0.12.0" />);
+      expect(component.find('TemplateCard')).toHaveLength(1);
+    });
+
+    it('displays everything with no semver', () => {
+      const component = shallow(<TemplateLibrary libraryProps={libraryProps} {...propInput} />);
+      expect(component.find('TemplateCard')).toHaveLength(templateArray.length);
+    });
+  });
 });


### PR DESCRIPTION
# Issue #180 

### Changes
- Added the `semver` property to TemplateLibrary, which allows for filtering based off of the provided semantic version

### Related Issues
- Issue #180 
