### PR TITLE
fix 187: allow error display to scroll in case of overflow

### DIFF
--- a/src/ErrorLogger/styles.js
+++ b/src/ErrorLogger/styles.js
@@ -8,6 +8,7 @@ export const ErrorDisplay = styled.div`
     width: 100%;
     position: fixed;
     max-height: 300px;
+    overflow-y: auto;
     background-color: ${props => props.displayBackground || '#1E2D53'};
     box-shadow: ${props => props.displayShadow || '0 -2px 20px 0 rgba(20,31,60,0.65)'};
     z-index: ${props => props.zIndexInput || 'auto'};


### PR DESCRIPTION
* allow the error display to scroll

Signed-off-by: Kedar Thakur <453473+starblind@users.noreply.github.com>

# Issue #187 
* allow the error display to scroll

### Changes
- add css to allow scrolling

### Flags
- <DESCRIBE ISSUES OR HOLDS FOR REVIEWERS>

### Related Issues
- Issue #<NUMBER HERE>
- Pull Request #<NUMBER HERE>
