### PR TITLE
fix(ClausePlugin): use withMutations to fix issue when pasting a clause node

### DIFF
--- a/src/plugins/ClausePlugin.js
+++ b/src/plugins/ClausePlugin.js
@@ -123,16 +123,18 @@ function ClausePlugin() {
         const isHeadingClause = node => node.type === 'clause';
         mutableNodes = mutableNodes.map((node) => {
           if (isHeadingClause(node)) {
-            const mutableNode = node.asMutable();
-            const mutableDataMap = mutableNode.data.asMutable();
-            const clauseUriSrc = mutableDataMap.get('src');
-            const generatedUUID = uuidv4();
-
-            mutableDataMap.set('clauseid', generatedUUID);
-            editor.props.clausePluginProps.pasteToContract(generatedUUID, clauseUriSrc, node.text);
-
-            mutableNode.data = mutableDataMap.asImmutable();
-            clausesToParse.push(node);
+            const mutableNode = node.withMutations((n) => {
+              const clauseUriSrc = n.data.get('src');
+              const generatedUUID = uuidv4();
+              const newData = n.data.withMutations((d) => {
+                d.set('clauseid', generatedUUID);
+              });
+              n.set('data', newData);
+              editor.props.clausePluginProps.pasteToContract(
+                generatedUUID, clauseUriSrc, node.text
+              );
+              clausesToParse.push(n);
+            });
             return mutableNode;
           }
           return node;


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

# Issue #134  
- When pasting a clause, an error would occur from slate where a node's key did not match its path

### Changes
- fix(ClausePlugin): use withMutations to fix issue when pasting a clause node
- This issue had to do with ImmutableJS and how we were manipulating the node. This PR uses `withMutations` to set new data on a node. (https://immutable-js.github.io/immutable-js/)

### Related Issues
- Pull Request #227 
