### PR TITLE
(fix) protect error component against bad input

### DIFF
--- a/src/ErrorLogger/index.js
+++ b/src/ErrorLogger/index.js
@@ -13,7 +13,7 @@ import ErrorComponent from './Error';
 
 const ErrorLogger = (props) => {
   const { errors, errorNav } = props;
-  const errorLength = Object.keys(errors).length;
+  const errorLength = Object.keys(errors).length ? Object.keys(errors).length : 0;
   const errorsProps = props.errorsProps || Object.create(null);
 
   const [errorsVisible, setErrorsVisible] = useState(false);


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

# Issue #226 

### Changes
- Protect ErrorComponent against non array input.

### Flags
- cicero-core has also been updated to ensure errors from `parse` are `ParseException`
