### PR TITLE
fix(TemplateLibrary): include displayname in search - I240

### DIFF
--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -105,7 +105,7 @@ const TemplateLibraryComponent = (props) => {
     if (query.length) {
       const regex = new RegExp(query, 'i');
       filteredTemplates = _.filter(filteredTemplates, t => (
-        t.name.match(regex) || t.uri.match(regex)
+        t.displayName.match(regex) || t.name.match(regex) || t.uri.match(regex)
       ));
     }
     return filteredTemplates;


### PR DESCRIPTION
# Issue #240
Allow user to search by `displayName`

### Changes
- Include `displayName` in search functionality

### Flags
- N/A

### Related Issues
- N/A
