### PR TITLE
feat(ContractEditor): pass onUndoOrRedo prop through to editor

### DIFF
--- a/src/ContractEditor/index.js
+++ b/src/ContractEditor/index.js
@@ -14,6 +14,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { KeyUtils } from 'slate';
 import { SlateAsInputEditor } from '@accordproject/markdown-editor';
 
 import ClausePlugin from '../plugins/ClausePlugin';
@@ -61,6 +62,11 @@ const contractProps = {
  */
 // eslint-disable-next-line react/display-name
 const ContractEditor = React.forwardRef((props, ref) => {
+  React.useEffect(() => {
+    const keygen = () => String(uuidv4()); // custom keys
+    KeyUtils.setGenerator(keygen);
+  }, []);
+
   const plugins = React.useMemo(() => (props.plugins
     ? props.plugins.concat(
       [VariablePlugin(), ConditionalPlugin(), ClausePlugin(), ComputedPlugin()]
@@ -73,7 +79,7 @@ const ContractEditor = React.forwardRef((props, ref) => {
     onChange={props.onChange || contractProps.onChange}
     plugins={plugins}
     lockText={props.lockText}
-    editorProps={props.editorProps}
+    editorProps={{ ...props.editorProps, onUndoOrRedo: props.onUndoOrRedo }}
     clausePluginProps={{
       loadTemplateObject: props.loadTemplateObject,
       onClauseUpdated: props.onClauseUpdated,
@@ -120,6 +126,7 @@ ContractEditor.propTypes = {
     HEADER_TITLE: PropTypes.string,
   }).isRequired,
   onClauseUpdated: PropTypes.func.isRequired,
+  onUndoOrRedo: PropTypes.func,
   plugins: PropTypes.arrayOf(PropTypes.shape({
     onEnter: PropTypes.func,
     onKeyDown: PropTypes.func,

--- a/src/ContractEditor/index.js
+++ b/src/ContractEditor/index.js
@@ -14,7 +14,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { KeyUtils } from 'slate';
 import { SlateAsInputEditor } from '@accordproject/markdown-editor';
 
 import ClausePlugin from '../plugins/ClausePlugin';
@@ -62,11 +61,6 @@ const contractProps = {
  */
 // eslint-disable-next-line react/display-name
 const ContractEditor = React.forwardRef((props, ref) => {
-  React.useEffect(() => {
-    const keygen = () => String(uuidv4()); // custom keys
-    KeyUtils.setGenerator(keygen);
-  }, []);
-
   const plugins = React.useMemo(() => (props.plugins
     ? props.plugins.concat(
       [VariablePlugin(), ConditionalPlugin(), ClausePlugin(), ComputedPlugin()]

--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -104,9 +104,10 @@ const TemplateLibraryComponent = (props) => {
     let filteredTemplates = templates;
     if (query.length) {
       const regex = new RegExp(query, 'i');
-      filteredTemplates = _.filter(filteredTemplates, t => (
-        t.displayName.match(regex) || t.name.match(regex) || t.uri.match(regex)
-      ));
+      filteredTemplates = _.filter(filteredTemplates, (t) => {
+        if (!t.displayName) return (t.name.match(regex) || t.uri.match(regex));
+        return (t.displayName.match(regex) || t.name.match(regex) || t.uri.match(regex));
+      });
     }
     return filteredTemplates;
   };


### PR DESCRIPTION
- feat(ContractEditor): pass onUndoOrRedo prop through to editor
- fix(TemplateLibrary): fix library bug when a template does not have a display name

### Related Issues
- Pull Request https://github.com/accordproject/markdown-editor/pull/206
