### PR TITLE
fix(plugins): check variable for toolbar methods - I253

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -290,11 +290,40 @@
       }
     },
     "@accordproject/markdown-slate": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.9.2.tgz",
-      "integrity": "sha512-Ng90kJPUhJwHCn0BapkXcK/1b3gDVTch6Lm6mb+x557ubCSBLEufAHdqq8xgUuyVKOllAjELNXwM1WoDO4Ssvw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.9.4.tgz",
+      "integrity": "sha512-oQnEg17dz4lum76MmiLw3Iz1jMywdjq/OHeMijWLbDRWLs07eSKuynRkkH5wbLbC3S/VTs+EnhrMnfRy+m5cDA==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.9.2"
+        "@accordproject/markdown-cicero": "0.9.4"
+      },
+      "dependencies": {
+        "@accordproject/markdown-cicero": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.4.tgz",
+          "integrity": "sha512-R7XReA19gXGmHcKwKd40CB6Ggd8Ono7cb1mycrNGXdRPkbBvhkEtRir3WmagMacLancc3YdgazRzXhIk7izcNQ==",
+          "requires": {
+            "@accordproject/concerto-core": "^0.82.6",
+            "@accordproject/markdown-common": "0.9.4",
+            "commonmark": "^0.29.0",
+            "jsome": "2.5.0",
+            "sax": "^1.2.4",
+            "winston": "3.2.1",
+            "xmldom": "^0.1.27"
+          }
+        },
+        "@accordproject/markdown-common": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.4.tgz",
+          "integrity": "sha512-NUSMBI0NjjRhBX+6uQjnkkTpQgtIP6GyYvVxazF2rdXb232a5JNlmMG0Qxf7LBC+DeAGB2Dxch5tzdVdWAoEeg==",
+          "requires": {
+            "@accordproject/concerto-core": "^0.82.6",
+            "commonmark": "^0.29.0",
+            "jsome": "2.5.0",
+            "sax": "^1.2.4",
+            "winston": "3.2.1",
+            "xmldom": "^0.1.27"
+          }
+        }
       }
     },
     "@babel/cli": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.2.tgz",
       "integrity": "sha512-/GSWyRoLO9rMZ6En0JUgPkeUT0AS9+GL4bm18Qs6ne+W/zJbSZK9EuAKADNhXEQf7dhKZ/i6j4RGQ3HqagzhSQ==",
+      "dev": true,
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
         "@accordproject/markdown-common": "0.9.2",
@@ -145,6 +146,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.2.tgz",
       "integrity": "sha512-soAOT8eZgFePDjv4a/mpJYDiqlD/qpq611qRCkQLByTSUfdA8jpypzoHiV+1arO/2P5Nt0EGqtsv/aowNTZ2HA==",
+      "dev": true,
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
         "commonmark": "^0.29.0",
@@ -155,12 +157,12 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.8.3.tgz",
-      "integrity": "sha512-VgjixYrHEdrLJzbhLSNLamSWuh8PUyyztLqDRFB29SPcUnJ8CaKBQIqXkci16A98lykiNGweef1NugPF3PRpBg==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.8.4.tgz",
+      "integrity": "sha512-XWzpIaBU2Byir7xXAL6/MC4NBuefg4Xf6F05jZD6cKAqFpkIQj8BX3cApwUzk+/fg8O+iXfqZAE0V+hOC5sukw==",
       "requires": {
-        "@accordproject/markdown-html": "^0.9.2",
-        "@accordproject/markdown-slate": "^0.9.2",
+        "@accordproject/markdown-html": "^0.9.4",
+        "@accordproject/markdown-slate": "^0.9.4",
         "css-loader": "^3.2.0",
         "immutable": "^3.8.2",
         "is-hotkey": "^0.1.6",
@@ -186,16 +188,43 @@
       }
     },
     "@accordproject/markdown-html": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.9.2.tgz",
-      "integrity": "sha512-aOHwRtqAev4bTxThMCJNvxtxcA+cHkjyIxV7eeFiW6ak+lIG9wKiF4d2yORkqf9nZY6QLXZe51p5ALRFUIDtGw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.9.4.tgz",
+      "integrity": "sha512-pUyPHKRZNUruzYvuqCCzIVnLpl3Fb+PwhduJCD4tg+KFL2pjuqLy4IremOeVYt0XPR8ykAJqXr6gZ5uHU7+JFg==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.9.2",
-        "@accordproject/markdown-common": "0.9.2",
+        "@accordproject/markdown-cicero": "0.9.4",
+        "@accordproject/markdown-common": "0.9.4",
         "jsdom": "^15.2.1",
         "type-of": "^2.0.1"
       },
       "dependencies": {
+        "@accordproject/markdown-cicero": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.4.tgz",
+          "integrity": "sha512-R7XReA19gXGmHcKwKd40CB6Ggd8Ono7cb1mycrNGXdRPkbBvhkEtRir3WmagMacLancc3YdgazRzXhIk7izcNQ==",
+          "requires": {
+            "@accordproject/concerto-core": "^0.82.6",
+            "@accordproject/markdown-common": "0.9.4",
+            "commonmark": "^0.29.0",
+            "jsome": "2.5.0",
+            "sax": "^1.2.4",
+            "winston": "3.2.1",
+            "xmldom": "^0.1.27"
+          }
+        },
+        "@accordproject/markdown-common": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.4.tgz",
+          "integrity": "sha512-NUSMBI0NjjRhBX+6uQjnkkTpQgtIP6GyYvVxazF2rdXb232a5JNlmMG0Qxf7LBC+DeAGB2Dxch5tzdVdWAoEeg==",
+          "requires": {
+            "@accordproject/concerto-core": "^0.82.6",
+            "commonmark": "^0.29.0",
+            "jsome": "2.5.0",
+            "sax": "^1.2.4",
+            "winston": "3.2.1",
+            "xmldom": "^0.1.27"
+          }
+        },
         "acorn": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
@@ -280,12 +309,9 @@
           }
         },
         "ws": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-          "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-          "requires": {
-            "async-limiter": "^1.0.0"
-          }
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+          "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
         }
       }
     },
@@ -2488,7 +2514,8 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "depcheck": "node ./scripts/depcheck.js"
   },
   "dependencies": {
-    "@accordproject/markdown-editor": "^0.8.3",
+    "@accordproject/markdown-editor": "^0.8.4",
     "@accordproject/markdown-slate": "^0.9.4",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@accordproject/markdown-editor": "^0.8.3",
-    "@accordproject/markdown-slate": "^0.9.2",
+    "@accordproject/markdown-slate": "^0.9.4",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.7.0",
     "node-sass": "^4.13.0",

--- a/src/plugins/VariablePlugin.js
+++ b/src/plugins/VariablePlugin.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import inVariableHelper from '../utilities/inVariable';
+import isToolbarMethodHelper from '../utilities/isToolbarMethod';
 
 /**
  * A plugin for a variable
@@ -41,6 +42,10 @@ function VariablePlugin() {
 
     const { anchor } = value.selection;
     console.log(`${code} - in variable ${inVariable}`, anchor.toJSON());
+
+    if (inVariable && isToolbarMethodHelper(code)) {
+      return false;
+    }
 
     if (code === 'backspace') {
       if (inVariable) {

--- a/src/utilities/isToolbarMethod.js
+++ b/src/utilities/isToolbarMethod.js
@@ -1,0 +1,17 @@
+const toolbarMethods = {
+  paragraph: true,
+  heading_one: true,
+  heading_two: true,
+  heading_three: true,
+  bold: true,
+  italic: true,
+  code: true,
+  block_quote: true,
+  ul_list: true,
+  ol_list: true,
+  undefined: true,
+};
+
+const isToolbarMethod = inputType => toolbarMethods[inputType] || false;
+
+export default isToolbarMethod;

--- a/src/utilities/isToolbarMethod.js
+++ b/src/utilities/isToolbarMethod.js
@@ -9,7 +9,7 @@ const toolbarMethods = {
   block_quote: true,
   ul_list: true,
   ol_list: true,
-  undefined: true,
+  hyperlink: true,
 };
 
 const isToolbarMethod = inputType => toolbarMethods[inputType] || false;


### PR DESCRIPTION
# Issue #253
Prevent application of markdown formatting to the content of variables in `lockText` mode

### Changes
- List formatting options in object for lookup to determine if allowed
- Upgrade to latest version of `markdown-transform`

### Flags
- Hyperlink action is listed as `undefined`

### Related Issues
- N/A
