### PR TITLE
feat(ContractEditor): allow readOnly props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.3.10",
+  "version": "0.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -157,9 +157,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.8.5.tgz",
-      "integrity": "sha512-Nz1o1kwbDToUcp9jeVdGCLwrJQFZ09V9GS7Htm/LltFhl3qE79c47wZKcss6+azJW90docto8zQWUnjj8d+OuA==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.8.6.tgz",
+      "integrity": "sha512-ZhXP/jN6Qiwcq239dxaMWIzcsOBsJsO9OwhmcHsIjzBuzpMttHvz5iCVYRIm66GhL+sbwyyWYFAYA1UBjcWJvg==",
       "requires": {
         "@accordproject/markdown-html": "^0.9.4",
         "@accordproject/markdown-slate": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "depcheck": "node ./scripts/depcheck.js"
   },
   "dependencies": {
-    "@accordproject/markdown-editor": "^0.8.5",
+    "@accordproject/markdown-editor": "^0.8.6",
     "@accordproject/markdown-slate": "^0.9.4",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.7.0",

--- a/src/ContractEditor/README.md
+++ b/src/ContractEditor/README.md
@@ -70,6 +70,7 @@ ReactDOM.render(<ContractEditor
 
 - `value`: An `object` which is the initial contents of the editor.
 - `lockText`: A `boolean` to lock all non variable text.
+- `readOnly`: A `boolean` to lock all text and remove the formatting toolbar.
 
 #### Functionality
 

--- a/src/ContractEditor/index.js
+++ b/src/ContractEditor/index.js
@@ -73,6 +73,7 @@ const ContractEditor = React.forwardRef((props, ref) => {
     onChange={props.onChange || contractProps.onChange}
     plugins={plugins}
     lockText={props.lockText}
+    readOnly={props.readOnly}
     editorProps={{ ...props.editorProps, onUndoOrRedo: props.onUndoOrRedo }}
     clausePluginProps={{
       loadTemplateObject: props.loadTemplateObject,
@@ -107,6 +108,7 @@ ContractEditor.propTypes = {
     WIDTH: PropTypes.string,
   }),
   lockText: PropTypes.bool,
+  readOnly: PropTypes.bool,
   loadTemplateObject: PropTypes.func.isRequired,
   pasteToContract: PropTypes.func.isRequired,
   clauseMap: PropTypes.object,


### PR DESCRIPTION
# No Issue

### Changes
- Pass the `readOnly` prop to disable the toolbar and edits

### Flags
- N/A

### Related Issues
- N/A