### PR TITLE
fix(ClauseComponent): remove icons in read-only mode

### DIFF
--- a/src/components/ClauseComponent.js
+++ b/src/components/ClauseComponent.js
@@ -96,21 +96,25 @@ function ClauseComponent(props) {
           {header}
         </S.HeaderToolTipText>
       </S.ClauseHeader>
-      <S.TestWrapper {...iconWrapperProps}>
-        <S.ClauseIcon {...testIconProps}>
-          {testIcon.icon()}
-        </ S.ClauseIcon>
-      </S.TestWrapper>
-      <S.EditWrapper {...iconWrapperProps}>
-        <S.ClauseIcon {...editIconProps}>
-          {editIcon.icon()}
-        </ S.ClauseIcon>
-      </S.EditWrapper>
-      <S.DeleteWrapper {...iconWrapperProps}>
-        <S.ClauseIcon {...deleteIconProps}>
-          {deleteIcon.icon()}
-        </ S.ClauseIcon>
-      </S.DeleteWrapper>
+      { !props.readOnly
+        && <>
+          <S.TestWrapper {...iconWrapperProps}>
+            <S.ClauseIcon {...testIconProps}>
+              {testIcon.icon()}
+            </ S.ClauseIcon>
+          </S.TestWrapper>
+          <S.EditWrapper {...iconWrapperProps}>
+            <S.ClauseIcon {...editIconProps}>
+              {editIcon.icon()}
+            </ S.ClauseIcon>
+          </S.EditWrapper>
+          <S.DeleteWrapper {...iconWrapperProps}>
+            <S.ClauseIcon {...deleteIconProps}>
+              {deleteIcon.icon()}
+            </ S.ClauseIcon>
+          </S.DeleteWrapper>
+        </>
+      }
       <S.ClauseBody
         bodyfont={clauseProps.BODY_FONT}
         variablecolor={clauseProps.VARIABLE_COLOR}
@@ -131,6 +135,7 @@ ClauseComponent.propTypes = {
     'data-key': PropTypes.string,
   }),
   errors: PropTypes.object,
+  readOnly: PropTypes.bool,
   removeFromContract: PropTypes.func,
   clauseId: PropTypes.string,
   clauseProps: PropTypes.shape({

--- a/src/plugins/ClausePlugin.js
+++ b/src/plugins/ClausePlugin.js
@@ -175,6 +175,7 @@ function ClausePlugin() {
   */
   function renderBlock(props, editor, next) {
     const loadTemplateCallback = editor.props.clausePluginProps.loadTemplateObject;
+    const { readOnly } = editor.props;
     const { clauseProps } = editor.props.clausePluginProps;
     const { node, children } = props;
 
@@ -192,6 +193,7 @@ function ClausePlugin() {
             clauseProps={clauseProps}
             templateUri={src}
             clauseId={clauseid}
+            readOnly={readOnly}
             {...props}>
               {children}
           </ClauseComponent>


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

# Issue
- Clause component icons for edit, test, and delete should not be shown in "read-only" mode

### Changes
- fix(ClauseComponent): remove icons in read-only mode
