### PR TITLE
style(src): improve clause components a11y - I57

### DIFF
--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -33,7 +33,7 @@ export const ClauseHeader = styled.div`
   justify-self: start;
   margin: 6px 0;
   padding: 3px;
-  color: ${props => props.headercolor || '#939EBA'};
+  color: ${props => props.headercolor || '#696969'};
   line-height: 14px;
   font-size: 0.87em;
   font-weight: 600;
@@ -41,7 +41,7 @@ export const ClauseHeader = styled.div`
 
 export const ClauseBody = styled.div`
   .variable {
-    color: ${props => props.variablecolor || '#009593'};
+    color: ${props => props.variablecolor || '#1034a6'};
   }
   .conditional {
     color: ${props => props.conditionalcolor || '#B11A00'};
@@ -58,7 +58,7 @@ export const ClauseBody = styled.div`
 `;
 
 export const ClauseIcon = styled.svg`
-  fill: #939EBA;
+  fill: #696969;
   cursor: pointer;
 
   &:hover {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,7 @@
+a {
+    color: #0f52ba;
+}
+
 .parseError {
     background-color: #e98181;
 }


### PR DESCRIPTION
# Issue #57
I have checked and modified all the elements which weren't complying with the WCAG 2.0 Standards i.e. the contrast ratio was lesser than 4.5:1

### Changes
- The following graphic should explain the changes made in a descriptive manner

![Color-Codes-Solved](https://user-images.githubusercontent.com/41413622/75228256-d74cb300-57d5-11ea-9ef2-8d38649a2c50.png)

### Related Issues
- Builds upon the Pull Request #202 
