### PR TITLE
chore(deps): Upgrade markdown-editor dependency to 0.9.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -131,7 +131,6 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.0.tgz",
       "integrity": "sha512-O4pUyOgtDFfxVgGtY0ZrJ4i/ZgCqkf+h+hX7gPFfkpY2T3qsXjwptej9ysonjCFt9+xM7Yp/imC0WKECfjz4gw==",
-      "dev": true,
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
         "@accordproject/markdown-common": "0.10.0",
@@ -146,7 +145,6 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.0.tgz",
       "integrity": "sha512-zIZyX6ZbHi/xUWCTIGnwFmRK4UdaQ7oF15IGUPz64+/c1ZkMN2n4Py2blsSrFnW3xn5FtfN8stMa/7iPQU0VuA==",
-      "dev": true,
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
         "commonmark": "^0.29.0",
@@ -157,9 +155,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.7.tgz",
-      "integrity": "sha512-FzuoKWPNskvYv4wDC3l218KuUpc5ACRmuf+BRwf+Y2jd9t9sFeViNJYK58Cj+uISGLzW0BOcpGw7xF+OfCfNFw==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.8.tgz",
+      "integrity": "sha512-miV6EVly4MheKpINAJOWN4puLvkD9sH8CYCDhn2d/teipHW2863T2ireBpBM/Ry8xH72mFuQp8GvIysyGoualw==",
       "requires": {
         "@accordproject/markdown-html": "^0.10.0",
         "@accordproject/markdown-slate": "^0.10.0",
@@ -176,41 +174,6 @@
         "style-loader": "^0.23.1"
       },
       "dependencies": {
-        "@accordproject/markdown-cicero": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.0.tgz",
-          "integrity": "sha512-O4pUyOgtDFfxVgGtY0ZrJ4i/ZgCqkf+h+hX7gPFfkpY2T3qsXjwptej9ysonjCFt9+xM7Yp/imC0WKECfjz4gw==",
-          "requires": {
-            "@accordproject/concerto-core": "^0.82.6",
-            "@accordproject/markdown-common": "0.10.0",
-            "commonmark": "^0.29.0",
-            "jsome": "2.5.0",
-            "sax": "^1.2.4",
-            "winston": "3.2.1",
-            "xmldom": "^0.1.27"
-          }
-        },
-        "@accordproject/markdown-common": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.0.tgz",
-          "integrity": "sha512-zIZyX6ZbHi/xUWCTIGnwFmRK4UdaQ7oF15IGUPz64+/c1ZkMN2n4Py2blsSrFnW3xn5FtfN8stMa/7iPQU0VuA==",
-          "requires": {
-            "@accordproject/concerto-core": "^0.82.6",
-            "commonmark": "^0.29.0",
-            "jsome": "2.5.0",
-            "sax": "^1.2.4",
-            "winston": "3.2.1",
-            "xmldom": "^0.1.27"
-          }
-        },
-        "@accordproject/markdown-slate": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.10.0.tgz",
-          "integrity": "sha512-I9+q3QI1XeyCzZ5uNvoj7GT8azFqcXKOObpagSvnfL6FnrorlMhpFEpjkQhB63n51U9U5abXYGp+eBpUEYrF/w==",
-          "requires": {
-            "@accordproject/markdown-cicero": "0.10.0"
-          }
-        },
         "@babel/runtime": {
           "version": "7.8.4",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
@@ -242,33 +205,6 @@
         "type-of": "^2.0.1"
       },
       "dependencies": {
-        "@accordproject/markdown-cicero": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.0.tgz",
-          "integrity": "sha512-O4pUyOgtDFfxVgGtY0ZrJ4i/ZgCqkf+h+hX7gPFfkpY2T3qsXjwptej9ysonjCFt9+xM7Yp/imC0WKECfjz4gw==",
-          "requires": {
-            "@accordproject/concerto-core": "^0.82.6",
-            "@accordproject/markdown-common": "0.10.0",
-            "commonmark": "^0.29.0",
-            "jsome": "2.5.0",
-            "sax": "^1.2.4",
-            "winston": "3.2.1",
-            "xmldom": "^0.1.27"
-          }
-        },
-        "@accordproject/markdown-common": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.0.tgz",
-          "integrity": "sha512-zIZyX6ZbHi/xUWCTIGnwFmRK4UdaQ7oF15IGUPz64+/c1ZkMN2n4Py2blsSrFnW3xn5FtfN8stMa/7iPQU0VuA==",
-          "requires": {
-            "@accordproject/concerto-core": "^0.82.6",
-            "commonmark": "^0.29.0",
-            "jsome": "2.5.0",
-            "sax": "^1.2.4",
-            "winston": "3.2.1",
-            "xmldom": "^0.1.27"
-          }
-        },
         "acorn": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "cicero-ui React component",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "depcheck": "node ./scripts/depcheck.js"
   },
   "dependencies": {
-    "@accordproject/markdown-editor": "^0.9.7",
+    "@accordproject/markdown-editor": "^0.9.8",
     "@accordproject/markdown-slate": "^0.10.0",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.7.0",

--- a/src/ContractEditor/__snapshots__/index.test.js.snap
+++ b/src/ContractEditor/__snapshots__/index.test.js.snap
@@ -3,7 +3,9 @@
 exports[`<ContractEditor /> on initialization renders page correctly 1`] = `
 <body>
   <div>
-    <div>
+    <div
+      class="ap-markdown-editor"
+    >
       <div
         class="sc-ifAKCX hNozxa"
         id="slate-toolbar-wrapper-id"


### PR DESCRIPTION
### Changes
- Upgrade to Markdown Editor v0.9.8, https://github.com/accordproject/markdown-editor/releases/tag/v0.9.8