### PR TITLE
feat(navigation): restyle navigation sizing - 276

### DIFF
--- a/src/Navigation/generators.js
+++ b/src/Navigation/generators.js
@@ -2,7 +2,6 @@
 import React from 'react';
 
 /* Actions */
-import { truncateHeader } from './actions';
 
 /* Styling */
 import * as SC from './styles';
@@ -18,8 +17,7 @@ export const headerGenerator = (props) => {
 
   return headers.map((header) => {
     const { type, key } = header;
-    const heading = truncateHeader(header);
-    if (!heading) return null;
+    if (!header.text) return null;
     switch (type) {
       case 'clause':
         return (
@@ -28,7 +26,7 @@ export const headerGenerator = (props) => {
               onClick={() => navigateHeader(key, type)}
               {...props.styleProps}
           >
-              {truncateHeader(header)}
+              {header.text}
           </ SC.HeaderClause>
         );
       case 'heading_one':
@@ -38,7 +36,7 @@ export const headerGenerator = (props) => {
               onClick={() => navigateHeader(key, type)}
               {...props.styleProps}
           >
-              {truncateHeader(header)}
+              {header.text}
           </ SC.HeaderOne>
         );
       case 'heading_two':
@@ -48,7 +46,7 @@ export const headerGenerator = (props) => {
               onClick={() => navigateHeader(key, type)}
               {...props.styleProps}
           >
-              {truncateHeader(header)}
+               {header.text}
           </ SC.HeaderTwo>
         );
       case 'heading_three':
@@ -58,7 +56,7 @@ export const headerGenerator = (props) => {
               onClick={() => navigateHeader(key, type)}
               {...props.styleProps}
           >
-              {truncateHeader(header)}
+              {header.text}
           </ SC.HeaderThree>
         );
       default:

--- a/src/Navigation/styles.js
+++ b/src/Navigation/styles.js
@@ -7,7 +7,7 @@ export const NavigationWrapper = styled.div`
     position: ${props => props.positionValue || 'static'};
     top: ${props => props.topValue || 'auto'};
     max-height: ${props => props.navMaxHeight || '80vh'};
-    width: ${props => props.navWidth || '180px'};
+    width: ${props => props.navWidth || '15vw'};
     background-color: ${props => props.backgroundColor || 'inherit'};
     overflow-y: inherit;
 
@@ -20,7 +20,6 @@ export const NavigationWrapper = styled.div`
 /* Navigation Component Switch */
 
 export const Title = styled.a`
-    place-self: center;
     color: #FFFFFF;
     font-size: 1em;
     font-weight: bold;
@@ -50,8 +49,8 @@ export const Files = styled(Title)`
 /* Contract Navigation */
 
 export const ContractHeaders = styled.div`
-    overflow-y: scroll !important;
-    overflow-x: hidden;
+    overflow: hidden;
+    white-space: nowrap;
     padding-top: 10px;
 
     grid-area: body;
@@ -62,10 +61,11 @@ export const ContractHeaders = styled.div`
 `;
 
 export const HeaderOne = styled.div`
+    overflow: hidden;
+    text-overflow: ellipsis;
     margin-top: 2px;
     margin-bottom: 2px;
     height: 24px;
-    width: 185px;
     color: ${props => props.headerColor || '#B9BCC4'};
     font-family: "IBM Plex Sans";
     font-size: 1em;


### PR DESCRIPTION
# Issue # 276
Made the width of the navigation component adjust based on screen size and used CSS to determine when to truncate & add the ellipsis

### Changes
- updated generators.js
- updated Navigation/styles.js

### Flags
- Headings in navigation can appear to be truncated prematurely, especially on larger screens

### Related Issues
- N/A