### PR TITLE
feat(ClauseHeader): added tooltips to icons

### DIFF
--- a/src/components/ClauseComponent.js
+++ b/src/components/ClauseComponent.js
@@ -193,14 +193,14 @@ function ClauseComponent(props) {
       </S.ClauseHeader>
       { !props.readOnly
         && <>
-          <S.TestWrapper 
+          <S.TestWrapper
             {...iconWrapperProps}
             onMouseEnter={() => setHoveringTestIcon(true)}
             onMouseLeave={() => setHoveringTestIcon(false)}
             onClick={() => clauseProps.CLAUSE_TEST_FUNCTION(props)}
           >
-            <S.ClauseIcon 
-              {...testIconProps} 
+            <S.ClauseIcon
+              {...testIconProps}
               hovering={hoveringTestIcon}
             >
               {testIcon.icon()}
@@ -213,13 +213,13 @@ function ClauseComponent(props) {
               </S.HeaderToolTipWrapper>
             }
           </S.TestWrapper>
-          <S.EditWrapper 
+          <S.EditWrapper
             {...iconWrapperProps}
             onMouseEnter={() => setHoveringEditIcon(true)}
             onMouseLeave={() => setHoveringEditIcon(false)}
             onClick={() => clauseProps.CLAUSE_EDIT_FUNCTION(props)}
           >
-            <S.ClauseIcon 
+            <S.ClauseIcon
               {...editIconProps}
               hovering={hoveringEditIcon}
             >
@@ -233,13 +233,13 @@ function ClauseComponent(props) {
               </S.HeaderToolTipWrapper>
             }
           </S.EditWrapper>
-          <S.DeleteWrapper 
+          <S.DeleteWrapper
             {...iconWrapperProps}
             onMouseEnter={() => setHoveringDeleteIcon(true)}
             onMouseLeave={() => setHoveringDeleteIcon(false)}
             onClick={() => clauseProps.CLAUSE_DELETE_FUNCTION(props)}
           >
-            <S.ClauseIcon 
+            <S.ClauseIcon
               {...deleteIconProps}
               hovering={hoveringDeleteIcon}
             >

--- a/src/components/ClauseComponent.js
+++ b/src/components/ClauseComponent.js
@@ -28,8 +28,14 @@ import ConditionalBoolean from './ConditionalBoolean';
  */
 function ClauseComponent(props) {
   const clauseProps = props.clauseProps || Object.create(null);
+
+  // Tooltip visibility controls
   const [hovering, setHovering] = useState(false);
   const [hoveringHeader, setHoveringHeader] = useState(false);
+  const [hoveringTestIcon, setHoveringTestIcon] = useState(false);
+  const [hoveringEditIcon, setHoveringEditIcon] = useState(false);
+  const [hoveringDeleteIcon, setHoveringDeleteIcon] = useState(false);
+
   const [conditionals, setConditionals] = useState({});
 
   const errorsComponent = props.errors
@@ -112,11 +118,10 @@ function ClauseComponent(props) {
 
   const testIconProps = {
     'aria-label': testIcon.type,
-    width: '16px',
-    height: '20px',
+    width: '19px',
+    height: '19px',
     viewBox: '0 0 16 20',
-    clauseIconColor: clauseProps.CLAUSE_ICONS,
-    onClick: () => clauseProps.CLAUSE_TEST_FUNCTION(props)
+    clauseIconColor: clauseProps.CLAUSE_ICONS
   };
 
   const editIconProps = {
@@ -124,17 +129,15 @@ function ClauseComponent(props) {
     width: '19px',
     height: '19px',
     viewBox: '0 0 19 19',
-    clauseIconColor: clauseProps.CLAUSE_ICONS,
-    onClick: () => clauseProps.CLAUSE_EDIT_FUNCTION(props)
+    clauseIconColor: clauseProps.CLAUSE_ICONS
   };
 
   const deleteIconProps = {
     'aria-label': deleteIcon.type,
-    width: '15px',
+    width: '19px',
     height: '19px',
     viewBox: '0 0 12 15',
-    clauseIconColor: clauseProps.CLAUSE_ICONS,
-    onClick: () => clauseProps.CLAUSE_DELETE_FUNCTION(props)
+    clauseIconColor: clauseProps.CLAUSE_ICONS
   };
 
   const conditionalIconProps = {
@@ -190,20 +193,65 @@ function ClauseComponent(props) {
       </S.ClauseHeader>
       { !props.readOnly
         && <>
-          <S.TestWrapper {...iconWrapperProps}>
-            <S.ClauseIcon {...testIconProps}>
+          <S.TestWrapper 
+            {...iconWrapperProps}
+            onMouseEnter={() => setHoveringTestIcon(true)}
+            onMouseLeave={() => setHoveringTestIcon(false)}
+            onClick={() => clauseProps.CLAUSE_TEST_FUNCTION(props)}
+          >
+            <S.ClauseIcon 
+              {...testIconProps} 
+              hovering={hoveringTestIcon}
+            >
               {testIcon.icon()}
             </ S.ClauseIcon>
+            {(hoveringTestIcon)
+              && <S.HeaderToolTipWrapper>
+                <S.HeaderToolTip>
+                  Test
+                </S.HeaderToolTip>
+              </S.HeaderToolTipWrapper>
+            }
           </S.TestWrapper>
-          <S.EditWrapper {...iconWrapperProps}>
-            <S.ClauseIcon {...editIconProps}>
+          <S.EditWrapper 
+            {...iconWrapperProps}
+            onMouseEnter={() => setHoveringEditIcon(true)}
+            onMouseLeave={() => setHoveringEditIcon(false)}
+            onClick={() => clauseProps.CLAUSE_EDIT_FUNCTION(props)}
+          >
+            <S.ClauseIcon 
+              {...editIconProps}
+              hovering={hoveringEditIcon}
+            >
               {editIcon.icon()}
             </ S.ClauseIcon>
+            {(hoveringEditIcon)
+              && <S.HeaderToolTipWrapper>
+                <S.HeaderToolTip>
+                  Edit
+                </S.HeaderToolTip>
+              </S.HeaderToolTipWrapper>
+            }
           </S.EditWrapper>
-          <S.DeleteWrapper {...iconWrapperProps}>
-            <S.ClauseIcon {...deleteIconProps}>
+          <S.DeleteWrapper 
+            {...iconWrapperProps}
+            onMouseEnter={() => setHoveringDeleteIcon(true)}
+            onMouseLeave={() => setHoveringDeleteIcon(false)}
+            onClick={() => clauseProps.CLAUSE_DELETE_FUNCTION(props)}
+          >
+            <S.ClauseIcon 
+              {...deleteIconProps}
+              hovering={hoveringDeleteIcon}
+            >
               {deleteIcon.icon()}
             </ S.ClauseIcon>
+            {(hoveringDeleteIcon)
+              && <S.HeaderToolTipWrapper>
+                <S.HeaderToolTip>
+                  Delete
+                </S.HeaderToolTip>
+              </S.HeaderToolTipWrapper>
+            }
           </S.DeleteWrapper>
         </>
       }

--- a/src/components/__snapshots__/index.test.js.snap
+++ b/src/components/__snapshots__/index.test.js.snap
@@ -22,13 +22,16 @@ exports[`<ClauseComponent /> on initialization renders component correctly 1`] =
   </styled.div>
   <Styled(styled.div)
     currentHover={false}
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <styled.svg
       aria-label={[Function]}
-      height="20px"
-      onClick={[Function]}
+      height="19px"
+      hovering={false}
       viewBox="0 0 16 20"
-      width="16px"
+      width="19px"
     >
       <g
         fillRule="evenodd"
@@ -50,11 +53,14 @@ exports[`<ClauseComponent /> on initialization renders component correctly 1`] =
   </Styled(styled.div)>
   <Styled(styled.div)
     currentHover={false}
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <styled.svg
       aria-label={[Function]}
       height="19px"
-      onClick={[Function]}
+      hovering={false}
       viewBox="0 0 19 19"
       width="19px"
     >
@@ -74,13 +80,16 @@ exports[`<ClauseComponent /> on initialization renders component correctly 1`] =
   </Styled(styled.div)>
   <Styled(styled.div)
     currentHover={false}
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <styled.svg
       aria-label={[Function]}
       height="19px"
-      onClick={[Function]}
+      hovering={false}
       viewBox="0 0 12 15"
-      width="15px"
+      width="19px"
     >
       <g
         fillRule="evenodd"

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -84,20 +84,21 @@ export const ClauseBody = styled.div`
 `;
 
 export const ClauseIcon = styled.svg`
-  fill: #696969;
+  position: relative;
+  z-index: 1;
   cursor: pointer;
-
-  &:hover {
-    fill: ${props => props.clauseIconColor || '#19C6C7'};
-  }
+  fill: ${props => (props.hovering ? props.clauseIconColor || '#19C6C7' : '#696969')};
 `;
 
 const IconWrapper = styled.div`
   visibility: ${props => (props.currentHover ? 'visible' : 'hidden')};
-  background: linear-gradient(180deg, #FFFFFF 0%, ${props => props.iconBg || '#ECF0FA'} 100%);
+  background: linear-gradient(180deg, #FFF 0%, ${props => props.iconBg || '#F9FBFF'} 100%);
+  position: relative;
+  z-index: 1;
   padding: 4px;
   place-self: center;
   transition-duration: 0.5s;
+  cursor: pointer;
 `;
 
 export const TestWrapper = styled(IconWrapper)`
@@ -126,21 +127,31 @@ export const ClauseAdd = styled.svg`
 
 export const HeaderToolTipWrapper = styled.div`
   position: absolute;
-  top: -25px;
+  top: -40px;
+  z-index: 99;
 `;
 
 export const HeaderToolTip = styled.div`
-  background-color: #141f3a;
+  background-color: #121212;
+  padding: 10px;
   border-radius: 3px;
-  padding: 5px;
+  color: #f0f0f0;
+  z-index: 99;
+  font-family: 'IBM Plex Sans', 'sans-serif';
+  transition: all 0.3s ease;
   :after {
     content: " ";
+    display: block;
+    width: 0;
+    height: 0;
+    z-index: 99;
     position: absolute;
     top: 100%;
     left: 5px;
-    border-width: 4px;
+    border-radius: 0px;
+    border-width: 6px;
     border-style: solid;
-    border-color: #141f3a transparent transparent transparent;
+    border-color: #121212 transparent transparent transparent;
   }
 `;
 


### PR DESCRIPTION
Signed-off-by: elit-altum <manan.sharma311@gmail.com>

Continues: https://github.com/accordproject/markdown-editor/issues/124
<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- Modified the ClauseBackground UI according to the proposed changes.
- Added tooltips on all the ClauseHeader icons for more information.

### Screenshot

![Tooltip-fixing](https://user-images.githubusercontent.com/41413622/75627272-be3c6b80-5bf4-11ea-9bb5-bd5a70c7976d.gif)


### Flags
- Design modifications and suggestions are welcome!

### Related Issues
- Pull Request: #247
