### PR TITLE
style(ClauseTemplate): change ClauseTemplate background color - I322

### DIFF
--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -43,7 +43,7 @@ export const ClauseConditionalTooltip = styled.div`
 `;
 
 export const ClauseBackground = styled.div`
-  background-color: ${props => props.clausebg || '#ECF0FA'};
+  background-color: ${props => props.clausebg || '#F9FBFF'};
   border: 1px solid ${props => props.clauseborder || '#19C6C7'};
   border-radius: 3px;
   grid-area: eight / eight / twentyone / twentyone;


### PR DESCRIPTION
Signed-off-by: Shrey Sachdeva <shreysachdeva.2000@gmail.com>

# Issue #322 
Change clause template background color from #ECF0FA to #F9FBFF to increase contrast. Increased contrast will improve accessibility and allow more flexibility for how we design future improvements.

### Changes
- Change clause template background color from #ECF0FA to #F9FBFF

Earlier:
![image](https://user-images.githubusercontent.com/47667325/76008882-61172180-5f36-11ea-9dd9-0ca70f6ddd0b.png)
Now:
![image](https://user-images.githubusercontent.com/47667325/76008868-5a88aa00-5f36-11ea-93c4-dbb36a298477.png)


### Flags
- N/A

### Related Issues
- Issue #314 