### PR TITLE
feat(ClauseComponent): UI enhancements to ClauseComponent

### DIFF
--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -44,8 +44,6 @@ export const ClauseConditionalTooltip = styled.div`
 
 export const ClauseBackground = styled.div`
   background-color: ${props => props.clausebg || '#F9FBFF'};
-  border: 1px solid ${props => props.clauseborder || '#19C6C7'};
-  border-radius: 3px;
   grid-area: eight / eight / twentyone / twentyone;
 `;
 
@@ -78,6 +76,7 @@ export const ClauseBody = styled.div`
   font-family: ${props => props.bodyfont || 'serif'};
   grid-area: sixteen / sixteen / twenty / twenty;
   margin: 2px 0 10px;
+  padding: 10px;
   color: #141F3C;
   font-size: 1em;
   line-height: 22px;


### PR DESCRIPTION
Signed-off-by: elit-altum <manan.sharma311@gmail.com>

Continues https://github.com/accordproject/cicero-ui/pull/318 by creating a different PR for UI styling of ClauseComponent

### Changes
- Increased the padding of ```ClauseBody```
- Removed the borders for a cleaner look

__Screenshot__
![image](https://user-images.githubusercontent.com/41413622/76015012-958fdb00-5f40-11ea-8824-4e7a0a6d0116.png)


### Related Issues
- Issue https://github.com/accordproject/markdown-editor/issues/124
- Pull Request #318 
