### PR TITLE
fix(styles.js): disables tooltip text selection - I330

### DIFF
--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -131,7 +131,9 @@ export const HeaderToolTipWrapper = styled.div`
   z-index: 99;
 `;
 
-export const HeaderToolTip = styled.div`
+export const HeaderToolTip = styled.div.attrs({
+  'contentEditable': 'false'
+})`
   background-color: #121212;
   padding: 10px;
   border-radius: 3px;


### PR DESCRIPTION
Signed-off-by: elit-altum <manan.sharma311@gmail.com>

# Issue #330 
Fixed tooltips text getting selected by multiple clicks on the icons.

### Changes
- Added the ```contentEditable="false"``` attribute to the tooltips ```styled.div```

![Tooltip-fixing-selection-after](https://user-images.githubusercontent.com/41413622/76401147-744b4680-63a7-11ea-9b44-dd35245451dd.gif)


Thanks @DianaLease for the suggestion! 💯 

### Related Issues
- Issue #330 
