### PR TITLE
feat(TemplateLibrary): add fallback message if template is not found

### DIFF
--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -148,7 +148,7 @@ const TemplateLibraryComponent = (props) => {
               libraryProps={libraryProps}
             />
           ))}
-        </TemplateCards> : <div style={{ textAlign: 'center' }}>No results found !</div>}
+        </TemplateCards> : <p style={{ textAlign: 'center' }}>No results found</p>}
       </TemplatesWrapper>
   );
 };

--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -137,7 +137,7 @@ const TemplateLibraryComponent = (props) => {
           {props.addTemp
           && <NewClauseComponent addTempInput={props.addTemp} />}
         </Functionality>
-        <TemplateCards tempsHeight={libraryProps.TEMPLATES_HEIGHT} >
+        {filtered.length ? <TemplateCards tempsHeight={libraryProps.TEMPLATES_HEIGHT} >
           {_.sortBy(filtered, ['name']).map(t => (
             <TemplateCard
               key={t.uri}
@@ -148,7 +148,7 @@ const TemplateLibraryComponent = (props) => {
               libraryProps={libraryProps}
             />
           ))}
-        </TemplateCards>
+        </TemplateCards> : <div style={{ textAlign: 'center' }}>No results found !</div>}
       </TemplatesWrapper>
   );
 };


### PR DESCRIPTION
Signed-off-by: nik72619c <nikhilsharmarockstar21@gmail.com>

# Issue #359
Added a fallback message which would indicate that `no results were found` if on search, no template could be found

### Changes
- Added a condition for checking if the length of `filtered` is not zero

<img width="329" alt="Screenshot 2020-03-29 at 8 48 14 PM" src="https://user-images.githubusercontent.com/30630904/77853302-1e78fa00-7201-11ea-9fa5-0ad1a52172c3.png">


@irmerk @Michael-Grover let me know of any design changes on this, will add it this PR :)
