### PR TITLE
feat(HeaderImport): fixed extra clickable area of import links

### DIFF
--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -49,6 +49,7 @@ const HeaderTitle = styled.p`
 const HeaderImports = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
 `;
 
 const Functionality = styled.div`


### PR DESCRIPTION
Signed-off-by: nik72619c <nikhilsharmarockstar21@gmail.com>

# Issue #365 
This PR fixes the issue of extra clickable area  for the import buttons. The buttons would not have an extended area, but would rather be clickable till their content width.

### Changes
Added the property `align-items: flex-end` so that their widths are not overflown

![WhatsApp Image 2020-04-05 at 12 11 37 AM](https://user-images.githubusercontent.com/30630904/78458854-2689db80-76d2-11ea-9e0f-d5feb980ea45.jpeg)

@DianaLease @irmerk Please review and suggest changes if any :)