### PR TITLE
chore(dep) Upgrade dependencies for Cicero 0.20.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "@accordproject/cicero-ui",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@accordproject/cicero-core": {
-      "version": "0.20.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.20.9.tgz",
-      "integrity": "sha512-gU0Sk+aCNBJ/eOHK6zVGWCK+ZJolAEugzbu2C3CeNuEp+X4tAw95MDAHly4YELOa7ZMfAyBxG+B3XoY1yJAD+w==",
+      "version": "0.20.10",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.20.10.tgz",
+      "integrity": "sha512-9faG7kVWJRz7chteVlwsaLpMbS3yLW35tZ0yGkuuiGFvVeZB3hbV5Sdzl21qOri14RqFp5oPgiPS83iFOU/IOw==",
       "dev": true,
       "requires": {
-        "@accordproject/concerto-core": "0.82.6",
-        "@accordproject/ergo-compiler": "0.20.9",
-        "@accordproject/ergo-engine": "0.20.9",
-        "@accordproject/markdown-common": "0.10.0",
+        "@accordproject/concerto-core": "0.82.7",
+        "@accordproject/ergo-compiler": "0.20.10",
+        "@accordproject/ergo-engine": "0.20.10",
+        "@accordproject/markdown-cicero": "0.10.4",
+        "@accordproject/markdown-common": "0.10.4",
+        "@accordproject/markdown-html": "0.10.4",
         "axios": "0.19.0",
         "debug": "4.1.0",
         "ietf-language-tag-regex": "0.0.5",
@@ -32,50 +34,6 @@
         "xregexp": "4.2.4"
       },
       "dependencies": {
-        "@accordproject/concerto-core": {
-          "version": "0.82.6",
-          "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.6.tgz",
-          "integrity": "sha512-owLRt8ok9vTTBAiwWq7pc2kepmoDEaIDW/WN2f2I8JEd0olz4EPabipMD1n18vmJCGR1QMonSXPreZHMUInODQ==",
-          "dev": true,
-          "requires": {
-            "axios": "0.19.0",
-            "debug": "4.1.1",
-            "fast-safe-stringify": "2.0.7",
-            "jsome": "2.5.0",
-            "lorem-ipsum": "1.0.6",
-            "moment-mini": "2.22.1",
-            "slash": "3.0.0",
-            "triple-beam": "1.3.0",
-            "urijs": "1.19.1",
-            "uuid": "3.3.2",
-            "winston": "3.2.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "dev": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
-          }
-        },
-        "@accordproject/markdown-common": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.0.tgz",
-          "integrity": "sha512-zIZyX6ZbHi/xUWCTIGnwFmRK4UdaQ7oF15IGUPz64+/c1ZkMN2n4Py2blsSrFnW3xn5FtfN8stMa/7iPQU0VuA==",
-          "dev": true,
-          "requires": {
-            "@accordproject/concerto-core": "^0.82.6",
-            "commonmark": "^0.29.0",
-            "jsome": "2.5.0",
-            "sax": "^1.2.4",
-            "winston": "3.2.1",
-            "xmldom": "^0.1.27"
-          }
-        },
         "debug": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
@@ -182,14 +140,12 @@
       }
     },
     "@accordproject/ergo-compiler": {
-      "version": "0.20.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.20.9.tgz",
-      "integrity": "sha512-f3N3amyM2x6maHBRcnDqcAB5Co5zMbMzIuz2VHkAj41jk3yeU0KZvDpbGgjBNNDjJSzYvZK48Gv+sLM+IlmKKA==",
+      "version": "0.20.10",
+      "resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.20.10.tgz",
+      "integrity": "sha512-7E+X9pLrmw8o/mVdYR4UieK7NQr90ogzEh8/N0pg6c/Az0VijA6L5ilmPFfkAqwWPlpgmr/5anGDixCN3m+yFg==",
       "dev": true,
       "requires": {
-        "@accordproject/concerto-core": "0.82.6",
-        "@accordproject/markdown-cicero": "0.10.0",
-        "@accordproject/markdown-common": "0.10.0",
+        "@accordproject/concerto-core": "0.82.7",
         "acorn": "5.1.2",
         "debug": "4.1.0",
         "doctrine": "3.0.0",
@@ -201,71 +157,6 @@
         "winston": "3.2.1"
       },
       "dependencies": {
-        "@accordproject/concerto-core": {
-          "version": "0.82.6",
-          "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.6.tgz",
-          "integrity": "sha512-owLRt8ok9vTTBAiwWq7pc2kepmoDEaIDW/WN2f2I8JEd0olz4EPabipMD1n18vmJCGR1QMonSXPreZHMUInODQ==",
-          "dev": true,
-          "requires": {
-            "axios": "0.19.0",
-            "debug": "4.1.1",
-            "fast-safe-stringify": "2.0.7",
-            "jsome": "2.5.0",
-            "lorem-ipsum": "1.0.6",
-            "moment-mini": "2.22.1",
-            "slash": "3.0.0",
-            "triple-beam": "1.3.0",
-            "urijs": "1.19.1",
-            "uuid": "3.3.2",
-            "winston": "3.2.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "dev": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "fast-safe-stringify": {
-              "version": "2.0.7",
-              "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-              "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-              "dev": true
-            }
-          }
-        },
-        "@accordproject/markdown-cicero": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.0.tgz",
-          "integrity": "sha512-O4pUyOgtDFfxVgGtY0ZrJ4i/ZgCqkf+h+hX7gPFfkpY2T3qsXjwptej9ysonjCFt9+xM7Yp/imC0WKECfjz4gw==",
-          "dev": true,
-          "requires": {
-            "@accordproject/concerto-core": "^0.82.6",
-            "@accordproject/markdown-common": "0.10.0",
-            "commonmark": "^0.29.0",
-            "jsome": "2.5.0",
-            "sax": "^1.2.4",
-            "winston": "3.2.1",
-            "xmldom": "^0.1.27"
-          }
-        },
-        "@accordproject/markdown-common": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.0.tgz",
-          "integrity": "sha512-zIZyX6ZbHi/xUWCTIGnwFmRK4UdaQ7oF15IGUPz64+/c1ZkMN2n4Py2blsSrFnW3xn5FtfN8stMa/7iPQU0VuA==",
-          "dev": true,
-          "requires": {
-            "@accordproject/concerto-core": "^0.82.6",
-            "commonmark": "^0.29.0",
-            "jsome": "2.5.0",
-            "sax": "^1.2.4",
-            "winston": "3.2.1",
-            "xmldom": "^0.1.27"
-          }
-        },
         "acorn": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
@@ -296,23 +187,23 @@
       }
     },
     "@accordproject/ergo-engine": {
-      "version": "0.20.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.20.9.tgz",
-      "integrity": "sha512-Rycc61fXHO9U/V8DmuL8Z1eR0uwECAwCQMxY72v2W5bkHzSwo0UystTtBXzowBfESfVf89yO2zPt0E+GmTpLdw==",
+      "version": "0.20.10",
+      "resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.20.10.tgz",
+      "integrity": "sha512-Jo5cINWssSc4XjEMquNNgqcoQoxDJcEd/6VNeX14SGxYhfimrq4u8MG+sFLJwJw+AO4g+kLUH/hZ9hEBO9WmUg==",
       "dev": true,
       "requires": {
-        "@accordproject/ergo-compiler": "0.20.9",
+        "@accordproject/ergo-compiler": "0.20.10",
         "moment-mini": "2.22.1",
         "vm2": "3.5.0"
       }
     },
     "@accordproject/markdown-cicero": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.3.tgz",
-      "integrity": "sha512-kYMnybTXEP49P8hpmDm51/GBWagXEjXl08a9vCwxa/uMq8GijuHcNLWjTerM7scUA1gPoXUW1PnL869BS2x2NA==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.4.tgz",
+      "integrity": "sha512-GTMXcs6wJ+Roj2FG9t1qxHmsLDPjj5zywLifX+4FFnUi2eIaH3wThzuo0MrCnYs3bKuGHvANYrDXQawOhXiNyg==",
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
-        "@accordproject/markdown-common": "0.10.3",
+        "@accordproject/markdown-common": "0.10.4",
         "commonmark": "^0.29.0",
         "jsome": "2.5.0",
         "sax": "^1.2.4",
@@ -321,9 +212,9 @@
       }
     },
     "@accordproject/markdown-common": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.3.tgz",
-      "integrity": "sha512-c40rVu5dNrW3nX+3cOWB8tnQxVp1Js7ufTowM3lSo8TD7I/Icx9VJqQVm49gE/LDT4oJ5dZWTydJMV1ilqwuRg==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.4.tgz",
+      "integrity": "sha512-2R/p8xrTALWBctRyIiatv5GEWLb2sU5YtTrhtzgYngPdSNzUmMQ3LTHTC5MW3nIzEaScRpFwDdI9vukDihWOhw==",
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
         "commonmark": "^0.29.0",
@@ -334,12 +225,12 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.15.tgz",
-      "integrity": "sha512-IrlMeUaO7ECKlHB/qQZq30J97pHX/GSdnhS36xn+FVIS6qEncCXzetC7JlqQX6n+wvN+J8Yjf5baNWCWgOsYmA==",
+      "version": "0.9.17",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.17.tgz",
+      "integrity": "sha512-O9fjVKQDB11CfGozd4lBBXjTeFakzrg2AHm9AoseKKrJEgyZi/+IMg7LPn9X+LH+p+C7t6YVd+h015XDZRZZxg==",
       "requires": {
-        "@accordproject/markdown-html": "^0.10.3",
-        "@accordproject/markdown-slate": "^0.10.3",
+        "@accordproject/markdown-html": "^0.10.4",
+        "@accordproject/markdown-slate": "^0.10.4",
         "@babel/runtime": "^7.8.7",
         "css-loader": "^3.4.2",
         "immutable": "^3.8.2",
@@ -361,22 +252,22 @@
       }
     },
     "@accordproject/markdown-html": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.10.3.tgz",
-      "integrity": "sha512-b7rKfI9h23/aQhlFb5HfE8gy5LOkKLHtZ5UxdicnXpwaqMlBoQiJpJ4qfIM3eJ14zZITmPLjQAKFHWkcFh56CQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.10.4.tgz",
+      "integrity": "sha512-MTZScjZHOpk0yJG1R2n+LpbLusNbAkdHQKZitydcQioAXvoMhJisZ54Px33ZzETrqNKtIJoOvpxI01UOf9VYQA==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.10.3",
-        "@accordproject/markdown-common": "0.10.3",
+        "@accordproject/markdown-cicero": "0.10.4",
+        "@accordproject/markdown-common": "0.10.4",
         "jsdom": "^15.2.1",
         "type-of": "^2.0.1"
       }
     },
     "@accordproject/markdown-slate": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.10.3.tgz",
-      "integrity": "sha512-fHtZVn/ulWnklsrdjSSAKvJ7UvPjJuRMD8UxCIymDdCd10YoP695TM+/u18rjjqdbqZgvHqOUj0mhiWg5Ijyxg==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.10.4.tgz",
+      "integrity": "sha512-6ElAcjpC+HzfxJoKNv63qNdaXQEZT485jWuBXc/+GoQ/ZonJpXOwcKo9GBvqH2EdZoXtq92i/cDk/kG5GRCTEQ==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.10.3"
+        "@accordproject/markdown-cicero": "0.10.4"
       }
     },
     "@babel/cli": {
@@ -1421,9 +1312,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.7.tgz",
-      "integrity": "sha512-R8zbPiv25S0pGfMqAr55dRRxWB8vUeo3wicI4g9PFVBKmsy/9wmQUV1AaYW/kxRHUhx42TTh6F0+QO+4pwfYWg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.9.2.tgz",
+      "integrity": "sha512-ayjSOxuK2GaSDJFCtLgHnYjuMyIpViNujWrZo8GUpN60/n7juzJKK5yOo6RFVb0zdU9ACJFK+MsZrUnj3OmXMw==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "styled-components": ">= 4"
   },
   "devDependencies": {
-    "@accordproject/cicero-core": "0.20.10",
+    "@accordproject/cicero-core": "^0.20.10",
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "depcheck": "node ./scripts/depcheck.js"
   },
   "dependencies": {
-    "@accordproject/markdown-editor": "^0.9.15",
-    "@accordproject/markdown-slate": "^0.10.3",
+    "@accordproject/markdown-editor": "^0.9.17",
+    "@accordproject/markdown-slate": "^0.10.4",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.7.0",
     "node-sass": "^4.13.1",
@@ -39,7 +39,7 @@
     "styled-components": ">= 4"
   },
   "devDependencies": {
-    "@accordproject/cicero-core": "^0.20.9",
+    "@accordproject/cicero-core": "0.20.10",
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

This upgrades dependencies for:
- latest markdown transform `0.10.4`
- upcoming Cicero `0.20.19`
- corresponding version of the markdown editor for upcoming Cicero `0.20.10`