### PR TITLE
Check if clause node src is a template uri before calling loadTemplateCallback

### DIFF
--- a/src/plugins/ClausePlugin.js
+++ b/src/plugins/ClausePlugin.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 
 import '../styles.css';
 import ClauseComponent from '../components/ClauseComponent';
-
+import isTemplateUri from '../utilities/isTemplateUri';
 
 /**
  * A plugin for a clause embedded in a contract
@@ -183,7 +183,7 @@ function ClausePlugin() {
         const src = node.data.get('src');
         const clauseid = node.data.get('clauseid');
 
-        if (src) {
+        if (src && isTemplateUri(src.toString())) {
           loadTemplateCallback(src.toString());
         }
 

--- a/src/utilities/isTemplateUri.js
+++ b/src/utilities/isTemplateUri.js
@@ -1,0 +1,7 @@
+const isTemplateUri = (uri) => {
+  const regex = /[a-z0-9]{2,6}:\/\/[a-z0-9-_]+@[0-9\.]+#[0-9a-f]{64}/;
+
+  return regex.test(uri);
+}
+
+export default isTemplateUri;


### PR DESCRIPTION
This ensures that we are calling loadTemplateCallback function with a template uri. We have added support for kits in Clause and the src attribute may now also point to a kit uri. The regex for kit uri differs from the regex for template uri.