### PR TITLE
chore(package): increment markdown packages - I378

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -220,9 +220,11 @@ const Demo = () => {
   return (
     <Wrapper>
       <ContractEditor
+        ref={refUse}
+        lockText={true}
+        readOnly={false}
         value={slateValue}
         onChange={onContractChange}
-        ref={refUse}
         onClauseUpdated={(clauseNode => parseClause(clauseNode.data.src, clauseNode))}
       />
     </Wrapper>

--- a/package-lock.json
+++ b/package-lock.json
@@ -239,12 +239,12 @@
       }
     },
     "@accordproject/markdown-cicero": {
-      "version": "0.10.5-20200410190852",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.5-20200410190852.tgz",
-      "integrity": "sha512-5eZbVNYRjvSv1oUmkxGJv0/gD3PtwkV9cK+3R7Jj0SikJAXK/eO3uTMTQ7IhhnxUILMzzQxc32Bqz0d60PaRRw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.1.tgz",
+      "integrity": "sha512-H+HXa8BbUw/CjFy18NG6YI0LkxwEfOVWSa6y9at3gCBKNnxlvJbFqTyqckdXSGltbTCtXyHWVXZZeFyaAgIfcg==",
       "requires": {
-        "@accordproject/concerto-core": "^0.82.6",
-        "@accordproject/markdown-common": "0.10.5-20200410190852",
+        "@accordproject/concerto-core": "^0.82.7",
+        "@accordproject/markdown-common": "0.11.1",
         "commonmark": "^0.29.0",
         "jsome": "2.5.0",
         "sax": "^1.2.4",
@@ -253,11 +253,11 @@
       }
     },
     "@accordproject/markdown-common": {
-      "version": "0.10.5-20200410190852",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.5-20200410190852.tgz",
-      "integrity": "sha512-lsyqW908nDnZ8LdGartTHJhECYgElzGoMtmuqqr+pZ30TfFb94YEynJPRoSYF2FztwRYdtSqkpQFSM2MhD/+uQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.1.tgz",
+      "integrity": "sha512-DmpnMBoNP3vfi0LkKm6j9Te8MgIuNcZzk2GZS859nmhSzsXr/7tYpfPfpENYcjBBUh4WQPwLhLit3w9AwIE48Q==",
       "requires": {
-        "@accordproject/concerto-core": "^0.82.6",
+        "@accordproject/concerto-core": "^0.82.7",
         "commonmark": "^0.29.0",
         "jsome": "2.5.0",
         "sax": "^1.2.4",
@@ -266,12 +266,12 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.9.18-20200420182521",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.18-20200420182521.tgz",
-      "integrity": "sha512-1zc8yfg68WhlDhX4+YlmjEGkZXBEewriChOu9+ZBBqPjgKxbvNsZB3+3JQ8uYxsfZ4eptmMa+bP+Inm04Eu/uQ==",
+      "version": "0.9.18-20200424230108",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.18-20200424230108.tgz",
+      "integrity": "sha512-489r+VIJGBfKXJRK98twwNPMRY93SV4XwRlUxBbvl/YcyTSt2MbTAcgHGXO7zj9TIg/OHea09IiEcXZtb8jLtg==",
       "requires": {
-        "@accordproject/markdown-html": "0.10.5-20200410190852",
-        "@accordproject/markdown-slate": "0.10.5-20200410190852",
+        "@accordproject/markdown-html": "^0.11.1",
+        "@accordproject/markdown-slate": "^0.11.1",
         "@babel/runtime": "^7.8.7",
         "@material-ui/core": "^4.9.5",
         "@material-ui/icons": "^4.9.1",
@@ -287,22 +287,22 @@
       }
     },
     "@accordproject/markdown-html": {
-      "version": "0.10.5-20200410190852",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.10.5-20200410190852.tgz",
-      "integrity": "sha512-UJG6PCsXwsMNWVGWB3Et4sFzeK/Y2Js3n6XWAl1L8v9mh6m2gfdaQaRVEiofgxSAUIkICKKHJuY5r04jSDj5Hw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.1.tgz",
+      "integrity": "sha512-wmy8v6F0R9S+RX3QcrA3zO6e80RBIQwM+lYU7IARwL/mqwz1ywmvIdLmcMr/0h41d09pYTqZmBs77+29BOTuFQ==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.10.5-20200410190852",
-        "@accordproject/markdown-common": "0.10.5-20200410190852",
+        "@accordproject/markdown-cicero": "0.11.1",
+        "@accordproject/markdown-common": "0.11.1",
         "jsdom": "^15.2.1",
         "type-of": "^2.0.1"
       }
     },
     "@accordproject/markdown-slate": {
-      "version": "0.10.5-20200410190852",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.10.5-20200410190852.tgz",
-      "integrity": "sha512-BWMCI+Jt9GBRzdTfuMC1+o8P3w9g6LsreR6DrvrKSyQcpthDr4N9wdMfhDK/QuSIaUVwDMlfneSsaVU22gF6TA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.11.1.tgz",
+      "integrity": "sha512-r/ibP/vNTTxHji63hoHwqixUT5tAwoBG1MIYzzV5VFPB3R4GdoShimp2oaUylmHGRjAhZWlsxT4psUj7Q0V0vg==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.10.5-20200410190852"
+        "@accordproject/markdown-cicero": "0.11.1"
       }
     },
     "@babel/cli": {
@@ -1922,16 +1922,16 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.9.11",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.11.tgz",
-      "integrity": "sha512-S2Ha9GpTxzl29XMeMc8dQX2pj97yApNzuhe/23If53fMdg5Fmd3SgbE1bMbyXeKhxwtXZjOFxd0vU+W/sez8Ew==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.12.tgz",
+      "integrity": "sha512-JtRm1iNw3PRg+bzULS1uRKhdIJ2jhKO3/5ptO6kTADARsv5KmhzMbM+PYmVS09qm9Yu3ilwka4dYrtjqea53Lw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/react-transition-group": "^4.2.0",
+        "@material-ui/react-transition-group": "^4.3.0",
         "@material-ui/styles": "^4.9.10",
         "@material-ui/system": "^4.9.10",
         "@material-ui/types": "^5.0.1",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/utils": "^4.9.12",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",
         "hoist-non-react-statics": "^3.3.2",
@@ -1950,24 +1950,14 @@
       }
     },
     "@material-ui/react-transition-group": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/react-transition-group/-/react-transition-group-4.2.0.tgz",
-      "integrity": "sha512-4zapZ0gW1ZTws5aH9OGy3IMvtTV/olc7YrVSkM1WFu1FsrEhL+qarEniRjx7LjHt0gukFqoINfElI8v2boVMQA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/react-transition-group/-/react-transition-group-4.3.0.tgz",
+      "integrity": "sha512-CwQ0aXrlUynUTY6sh3UvKuvye1o92en20VGAs6TORnSxUYeRmkX8YeTUN3lAkGiBX1z222FxLFO36WWh6q73rQ==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "dom-helpers": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        }
       }
     },
     "@material-ui/styles": {
@@ -2009,9 +1999,9 @@
       "integrity": "sha512-wURPSY7/3+MAtng3i26g+WKwwNE3HEeqa/trDBR5+zWKmcjO+u9t7Npu/J1r+3dmIa/OeziN9D/18IrBKvKffw=="
     },
     "@material-ui/utils": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.6.tgz",
-      "integrity": "sha512-gqlBn0JPPTUZeAktn1rgMcy9Iczrr74ecx31tyZLVGdBGGzsxzM6PP6zeS7FuoLS6vG4hoZP7hWnOoHtkR0Kvw==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.12.tgz",
+      "integrity": "sha512-/0rgZPEOcZq5CFA4+4n6Q6zk7fi8skHhH2Bcra8R3epoJEYy5PL55LuMazPtPH1oKeRausDV/Omz4BbgFsn1HQ==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
@@ -19346,18 +19336,18 @@
       }
     },
     "slate-history": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.57.1.tgz",
-      "integrity": "sha512-pSUmGcIzFJ1ClaF2S5dFm7TBS30ZG3sqkwAowTxvD0+jafG/2I3N6M6M0anhkgBEGMU1rdNQqX4O6b/qKUJPgg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.57.2.tgz",
+      "integrity": "sha512-AncVHKP/l+A9kVY01+MFbuYy5vLJWYmZhyvYq4YdD4BtDzvIMLFAxRFR8MZoUOxBy0l3PeAxYFEd6mG2ay2Dyg==",
       "requires": {
         "immer": "^5.0.0",
         "is-plain-object": "^3.0.0"
       }
     },
     "slate-hyperscript": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/slate-hyperscript/-/slate-hyperscript-0.57.1.tgz",
-      "integrity": "sha512-2vA1kCl/DPuyWziSn8CnmjAnEgdNJvFmmGWwoabHBusBeWg0AS1pQpGsuR95r2tBQifF2pweRA0T/2T6nN/uHg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/slate-hyperscript/-/slate-hyperscript-0.57.2.tgz",
+      "integrity": "sha512-p5eQpdhEEfzKMFY2A8A5EWvE5kXKW+wEZWu1DAeMQqyYV1azdpKZP61YWvo3VtfYzGchTIEY/wUZJOh7tXJ2nw==",
       "requires": {
         "is-plain-object": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "storybook": "start-storybook -p 9001 -c .storybook -s ./assets"
   },
   "dependencies": {
-    "@accordproject/markdown-editor": "0.9.18-20200420182521",
-    "@accordproject/markdown-slate": "0.10.5-20200410190852",
+    "@accordproject/markdown-editor": "0.9.18-20200424230108",
+    "@accordproject/markdown-slate": "0.11.1",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.7.0",
     "node-sass": "^4.13.1",

--- a/src/ContractEditor/test/__snapshots__/index.test.js.snap
+++ b/src/ContractEditor/test/__snapshots__/index.test.js.snap
@@ -4,6 +4,7 @@ exports[`<ContractEditor /> on initialization renders page correctly 1`] = `
 <body>
   <div>
     <div
+      class="ap-rich-text-editor"
       data-gramm="false"
       data-slate-editor="true"
       data-slate-node="value"
@@ -13,6 +14,7 @@ exports[`<ContractEditor /> on initialization renders page correctly 1`] = `
       <h1
         class="sc-htpNat kiiZDr"
         data-slate-node="element"
+        id="Heading-One"
       >
         <span
           data-slate-node="text"


### PR DESCRIPTION
# Closes #378
Support Slate's rule for normalizing children with empty text nodes.

### Changes
- Update to newest `markdown-transform`

### Flags
- N/A

### Related Issues
- Closes #393
- [Transform PR #222](https://github.com/accordproject/markdown-transform/pull/222)
- [Slate #3637](https://github.com/ianstormtaylor/slate/pull/3637)
