### PR TITLE
fix(Conditional): swap without normalizing - I392

### DIFF
--- a/src/components/Conditional/index.js
+++ b/src/components/Conditional/index.js
@@ -1,6 +1,6 @@
 /* React */
 import React, { useState } from 'react';
-import { Transforms } from 'slate';
+import { Editor, Transforms } from 'slate';
 import PropTypes from 'prop-types';
 import { ReactEditor, useEditor } from 'slate-react';
 
@@ -54,8 +54,10 @@ const Conditional = (props) => {
           : conditional.whenFalse
       }]
     };
-    Transforms.removeNodes(editor, { at: path });
-    Transforms.insertNodes(editor, newConditional, { at: path });
+    Editor.withoutNormalizing(editor, () => {
+      Transforms.removeNodes(editor, { at: path });
+      Transforms.insertNodes(editor, newConditional, { at: path });
+    });
   };
 
   const conditionalProps = {


### PR DESCRIPTION
# Closes #392
Swap conditional nodes without normalizing the editor (which merges two similar text nodes between `removeNodes` and `insertNodes` function calls)

### Changes
- Prevent merging of text nodes while removing and inserting

### Flags
- N/A
