### PR TITLE
fix(plugins): disable forward delete at end of variable - I374

### DIFF
--- a/src/ContractEditor/plugins/withVariables.js
+++ b/src/ContractEditor/plugins/withVariables.js
@@ -34,7 +34,12 @@ export const isEditable = (lockText, editor, event) => {
   if (!lockText || !editor.isInsideClause()) return true;
   const { selection } = editor;
   const textLength = Node.get(editor, editor.selection.focus.path).text.length;
+  const atEnd = editor => textLength === editor.selection.focus.offset;
+
   if (inVariable(editor)) {
+    if (atEnd(editor) && event.inputType === 'deleteContentForward') {
+      return false;
+    }
     if (event.inputType === 'deleteContentBackward') {
       // Do not allow user to delete variable if only 1 char left
       if (textLength === 1) {


### PR DESCRIPTION
# Closes #374
Prevent forward deletion at the end of a variable

### Changes
- Check if cursor is at the end of a variable and is attempting to delete forward

### Flags
- Unsure if this addresses @jeromesimeon's [comments](https://github.com/accordproject/cicero-ui/issues/374#issuecomment-621316324)

### Related Issues
- `markdown-editor` PR [#340](https://github.com/accordproject/markdown-editor/pull/340)
