### PR TITLE
refactor(*): remove refs and only create debounced fn if fn exists

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -172,7 +172,6 @@ const Wrapper = styled.div`
  * A demo component that uses ContractEditor
  */
 const Demo = () => {
-  const refUse = useRef(null);
   const [slateValue, setSlateValue] = useState(() => {
     const slate = getContractSlateVal();
     return slate.document.children;
@@ -220,7 +219,6 @@ const Demo = () => {
   return (
     <Wrapper>
       <ContractEditor
-        ref={refUse}
         lockText={true}
         readOnly={false}
         value={slateValue}

--- a/src/ContractEditor/index.js
+++ b/src/ContractEditor/index.js
@@ -64,8 +64,7 @@ const contractProps = {
  *
  * @param {*} props the properties for the component
  */
-/* eslint react/display-name: 0 */
-const ContractEditor = React.forwardRef((props, ref) => {
+const ContractEditor = (props) => {
   const withClausesProps = {
     onClauseUpdated: props.onClauseUpdated,
     pasteToContract: props.pasteToContract
@@ -103,7 +102,6 @@ const ContractEditor = React.forwardRef((props, ref) => {
 
   return (
     <RichTextEditor
-      ref={ref}
       augmentEditor={augmentEditor}
       isEditable={(...args) => isEditable(props.lockText, ...args)}
       value={props.value || contractProps.value}
@@ -123,7 +121,7 @@ const ContractEditor = React.forwardRef((props, ref) => {
       // }}
   />
   );
-});
+};
 
 /**
  * The property types for this component
@@ -134,14 +132,14 @@ ContractEditor.propTypes = {
   onChange: PropTypes.func,
   lockText: PropTypes.bool,
   readOnly: PropTypes.bool,
-  pasteToContract: PropTypes.func.isRequired,
+  pasteToContract: PropTypes.func,
   clauseMap: PropTypes.object,
   clauseProps: PropTypes.shape({
     CLAUSE_DELETE_FUNCTION: PropTypes.func,
     CLAUSE_EDIT_FUNCTION: PropTypes.func,
     CLAUSE_TEST_FUNCTION: PropTypes.func,
-  }).isRequired,
-  onClauseUpdated: PropTypes.func.isRequired,
+  }),
+  onClauseUpdated: PropTypes.func,
   onUndoOrRedo: PropTypes.func,
   plugins: PropTypes.arrayOf(PropTypes.shape({
     onEnter: PropTypes.func,

--- a/src/ContractEditor/plugins/withClauses.js
+++ b/src/ContractEditor/plugins/withClauses.js
@@ -61,12 +61,12 @@ const isEditable = (editor, format) => {
 const withClauses = (editor, withClausesProps) => {
   const { insertData, onChange } = editor;
   const { onClauseUpdated, pasteToContract } = withClausesProps;
-  const debouncedOnClauseUpdated = _.debounce(onClauseUpdated, 1000, { maxWait: 10000 });
 
   editor.isInsideClause = () => isEditable(editor, CLAUSE);
 
   editor.onChange = () => {
     if (onClauseUpdated && editor.isInsideClause()) {
+      const debouncedOnClauseUpdated = _.debounce(onClauseUpdated, 1000, { maxWait: 10000 });
       const [clauseNode] = Editor.nodes(editor, { match: n => n.type === CLAUSE });
       debouncedOnClauseUpdated(clauseNode[0]);
     }


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

- Remove unused refs
- Don't create debounced `onClauseUpdated` unless it's passed in. Don't require it since it's not needed if using the editor in `readOnly` mode