### PR TITLE
refactor(template library): added fallback message if template list i…

### DIFF
--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -138,7 +138,7 @@ const TemplateLibraryComponent = (props) => {
           {props.addTemp
           && <NewClauseComponent addTempInput={props.addTemp} />}
         </Functionality>
-        <TemplateCards tempsHeight={libraryProps.TEMPLATES_HEIGHT} >
+        {filtered.length ? <TemplateCards tempsHeight={libraryProps.TEMPLATES_HEIGHT} >
           {_.sortBy(filtered, ['name']).map(t => (
             <TemplateCard
               key={t.uri}
@@ -149,7 +149,7 @@ const TemplateLibraryComponent = (props) => {
               libraryProps={libraryProps}
             />
           ))}
-        </TemplateCards>
+        </TemplateCards> : <p style={{ textAlign: 'center' }}>No results found</p>}
       </TemplatesWrapper>
   );
 };

--- a/src/TemplateLibrary/index.js
+++ b/src/TemplateLibrary/index.js
@@ -138,7 +138,7 @@ const TemplateLibraryComponent = (props) => {
           {props.addTemp
           && <NewClauseComponent addTempInput={props.addTemp} />}
         </Functionality>
-        {filtered.length ? <TemplateCards tempsHeight={libraryProps.TEMPLATES_HEIGHT} >
+        {filtered && filtered.length ? <TemplateCards tempsHeight={libraryProps.TEMPLATES_HEIGHT} >
           {_.sortBy(filtered, ['name']).map(t => (
             <TemplateCard
               key={t.uri}


### PR DESCRIPTION
Signed-off-by: nik72619c <nikhilsharmarockstar21@gmail.com>

# Issue #359
Added a fallback message which would indicate that `no results were found` if on search, no template could be found

### Changes
- Added a condition for checking if the length of `filtered` is not zero

<img width="402" alt="Screenshot 2020-05-01 at 6 49 47 PM" src="https://user-images.githubusercontent.com/30630904/80808171-93629980-8bdc-11ea-9655-a6092cd5fcb2.png">



@irmerk @Michael-Grover let me know of any design changes on this, will add it this PR :)
