### PR TITLE
refactor(withClauses): remove unused editor parameter and update md-editor dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,9 +266,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.9.18-20200429195104",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.18-20200429195104.tgz",
-      "integrity": "sha512-cb7V4wJbJ4l/7XOM+imCe/+VebHGwKxwU2xX2wOARMOtEaFyf0TUu83w6NwRQy7DC6vZx68tF82ymvTHdEVwqA==",
+      "version": "0.9.18-20200501200626",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.18-20200501200626.tgz",
+      "integrity": "sha512-+d1R2RYCDA2PZ1qjtm+94x8PY0qkkw7PRtJoNg0nugGX/VaWve0aMJAdD2TH78KP3B26HEPG5T/wy7MPEx0CNA==",
       "requires": {
         "@accordproject/markdown-html": "^0.11.2",
         "@accordproject/markdown-slate": "^0.11.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook -s ./assets"
   },
   "dependencies": {
-    "@accordproject/markdown-editor": "0.9.18-20200429195104",
+    "@accordproject/markdown-editor": "0.9.18-20200501200626",
     "@accordproject/markdown-slate": "^0.11.2",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.7.0",

--- a/src/ContractEditor/plugins/withClauses.js
+++ b/src/ContractEditor/plugins/withClauses.js
@@ -122,7 +122,7 @@ const withClauses = (editor, withClausesProps) => {
     insertData(data);
   };
 
-  editor.isClauseSupported = (editor, clauseNode) => {
+  editor.isClauseSupported = (clauseNode) => {
     const params = { depth: 0 };
     let children;
     if (clauseNode.document) {

--- a/src/ContractEditor/test/__snapshots__/index.test.js.snap
+++ b/src/ContractEditor/test/__snapshots__/index.test.js.snap
@@ -4,10 +4,10 @@ exports[`<ContractEditor /> on initialization renders page correctly 1`] = `
 <body>
   <div>
     <div
-      class="ap-rich-text-editor"
       data-gramm="false"
       data-slate-editor="true"
       data-slate-node="value"
+      id="ap-rich-text-editor"
       spellcheck="true"
       style="outline: none; white-space: pre-wrap; word-wrap: break-word;"
     >


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

refactor(withClauses): remove unused editor parameter (left over from previous slate version where it was always automatically passed as the first argument from slate)
chore(dep): update md-editor dep