### PR TITLE
feat(ContractEditor): prevent copy partial clause et al

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,9 +266,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.9.18-20200508153736",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.18-20200508153736.tgz",
-      "integrity": "sha512-9ZFDEvIRh37jldYVKK/3NKK/IJCKo92+/XHKZ43khF8m+JzljV1njjvmukAipyLaFdn4zEXgswpWoD+aLBdmHQ==",
+      "version": "0.9.18-20200511185451",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.9.18-20200511185451.tgz",
+      "integrity": "sha512-I+gmr4YoAB3iGC42yYRlYuFQtIY6OJeR1VDMV2plJjIApGLyORcxMw5cKO9uq/k1W3d3QSwfHhf2JF/n2TjZTQ==",
       "requires": {
         "@accordproject/markdown-html": "^0.11.2",
         "@accordproject/markdown-slate": "^0.11.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook -s ./assets"
   },
   "dependencies": {
-    "@accordproject/markdown-editor": "0.9.18-20200508153736",
+    "@accordproject/markdown-editor": "0.9.18-20200511185451",
     "@accordproject/markdown-slate": "^0.11.2",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.7.0",

--- a/src/ContractEditor/plugins/withClauses.js
+++ b/src/ContractEditor/plugins/withClauses.js
@@ -69,8 +69,10 @@ const withClauses = (editor, withClausesProps) => {
   const { insertData, onChange } = editor;
   const { onClauseUpdated, pasteToContract } = withClausesProps;
 
-  editor.isInsideClause = () => {
-    const [match] = Editor.nodes(editor, { match: n => n.type === CLAUSE });
+  editor.isInsideClause = (
+    input = { anchor: editor.selection.anchor, focus: editor.selection.focus }
+  ) => {
+    const [match] = Editor.nodes(editor, { match: n => n.type === CLAUSE, at: input });
     return !!match;
   };
 


### PR DESCRIPTION
# No Issue

### Changes
- Prevents deleting last paragraph if it follows a clause template
- Prevents copying if selection begins or ends in a clause template

### Flags
- Allows deleting all paragraphs between clause templates

### Related Issues
- [`markdown-editor` #396](https://github.com/accordproject/markdown-editor/pull/396)