### PR TITLE
fix(*): fix properties and refactor input param

### DIFF
--- a/src/ContractEditor/plugins/withClauses.js
+++ b/src/ContractEditor/plugins/withClauses.js
@@ -70,7 +70,7 @@ const withClauses = (editor, withClausesProps) => {
   const { onClauseUpdated, pasteToContract } = withClausesProps;
 
   editor.isInsideClause = (
-    input = { anchor: editor.selection.anchor, focus: editor.selection.focus }
+    input = editor.selection
   ) => {
     const [match] = Editor.nodes(editor, { match: n => n.type === CLAUSE, at: input });
     return !!match;

--- a/src/components/Clause/index.js
+++ b/src/components/Clause/index.js
@@ -40,6 +40,9 @@ const ClauseComponent = React.forwardRef((props, ref) => {
 
   const iconWrapperProps = {
     currentHover: hovering,
+    contentEditable: false,
+    suppressContentEditableWarning: true,
+    style: { userSelect: 'none' },
   };
 
   const testIconProps = {
@@ -85,7 +88,12 @@ const ClauseComponent = React.forwardRef((props, ref) => {
         ))
       } */}
         <S.ClauseBackground />
-        <S.ClauseHeader currentHover={hovering} >
+        <S.ClauseHeader
+          currentHover={hovering}
+          contentEditable={false}
+          suppressContentEditableWarning={true}
+          style={{ userSelect: 'none' }}
+        >
           {(hoveringHeader && header.length > 54)
             && <S.HeaderToolTipWrapper>
               <S.HeaderToolTip>


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

Add more `contentEditable` properties and `userSelect` CSS to non-editable properties according to this Slate slack convo: https://slate-js.slack.com/archives/C1RH7AXSS/p1588530291453700

This prevents a crash that can happen when Slate tries to find leaf nodes for these.
